### PR TITLE
Refactor/extract diagonal generation

### DIFF
--- a/lib/chess/moves/generator.ex
+++ b/lib/chess/moves/generator.ex
@@ -1,0 +1,14 @@
+defmodule Chess.Moves.Generator do
+  @moduledoc """
+  Module defining the Behaviour for move
+  generators.
+  """
+  alias Chess.Board
+
+  @doc """
+  Callback that takes a starting index and
+  returns an `Enumerable.t()` of a set of
+  potential moves based on the starting index.
+  """
+  @callback generate(Board.index()) :: Enumerable.t()
+end

--- a/lib/chess/moves/generators/diagonals.ex
+++ b/lib/chess/moves/generators/diagonals.ex
@@ -1,0 +1,52 @@
+defmodule Chess.Moves.Generators.Diagonals do
+  @moduledoc """
+  Exposes utility functions for generating sets of
+  potential moves along a diagonal.
+  """
+  alias Chess.Board
+  alias Chess.Moves.Generator
+
+  @behaviour Generator
+
+  @operators ~w(- - + +)a
+
+  @impl Generator
+  def generate(starting_index) do
+    {starting_col, starting_row} = Board.index_to_coordinates(starting_index)
+
+    starting_col
+    |> ranges()
+    |> Enum.zip(@operators)
+    |> Enum.map(fn {quadrant, operator} ->
+      Enum.reduce_while(
+        quadrant,
+        {MapSet.new(), apply(Kernel, operator, [starting_row, 1])},
+        &build_diagonal(&1, &2, operator)
+      )
+    end)
+    |> Enum.map(fn
+      {quadrant, _row} -> quadrant
+      quadrant -> quadrant
+    end)
+  end
+
+  @spec ranges(Board.index()) :: list(Board.index())
+  def ranges(starting_column) do
+    [(starting_column - 1)..1, (starting_column + 1)..8]
+    |> List.duplicate(2)
+    |> List.flatten()
+  end
+
+  @spec build_diagonal(integer(), {MapSet.t(Board.coordinates()), integer()}, :+ | :-) ::
+          {:halt, MapSet.t(Board.coordinates())}
+          | {:cont, {MapSet.t(Board.coordinates()), integer()}}
+  defp build_diagonal(column, {coords, row}, operator) do
+    case min(column, row) < 1 || max(column, row) > 8 do
+      true ->
+        {:halt, coords}
+
+      false ->
+        {:cont, {MapSet.put(coords, {column, row}), apply(Kernel, operator, [row, 1])}}
+    end
+  end
+end

--- a/lib/chess/moves/generators/diagonals.ex
+++ b/lib/chess/moves/generators/diagonals.ex
@@ -3,6 +3,8 @@ defmodule Chess.Moves.Generators.Diagonals do
   Exposes utility functions for generating sets of
   potential moves along a diagonal.
   """
+  use Nebulex.Caching
+
   alias Chess.Board
   alias Chess.Moves.Generator
 
@@ -10,6 +12,7 @@ defmodule Chess.Moves.Generators.Diagonals do
 
   @operators ~w(- - + +)a
 
+  @decorate cacheable(cache: Chess.Pieces.MoveCache, key: {__MODULE__, starting_index})
   @impl Generator
   def generate(starting_index) do
     {starting_col, starting_row} = Board.index_to_coordinates(starting_index)

--- a/test/chess/moves/generators/diagonals_test.exs
+++ b/test/chess/moves/generators/diagonals_test.exs
@@ -1,0 +1,15 @@
+defmodule Chess.Moves.Generators.DiagonalsTest do
+  use ExUnit.Case
+
+  alias Chess.Board
+  alias Chess.Moves.Generators.Diagonals
+
+  describe "c:generate/1" do
+    test "given starting index at {4, 4}, returns a list of sets along all diagonals" do
+      starting_index = Board.coordinates_to_index({4, 4})
+
+      assert [_quadrant_1, _quadrant_2, _quadrant_3, _quadrant_4] =
+               Diagonals.generate(starting_index)
+    end
+  end
+end

--- a/test/chess/moves/generators/diagonals_test.exs
+++ b/test/chess/moves/generators/diagonals_test.exs
@@ -25,5 +25,31 @@ defmodule Chess.Moves.Generators.DiagonalsTest do
 
       assert expected == quadrant
     end
+
+    test "given starting index at {8, 8}, returns only a single populated quadrant" do
+      assert quadrants = Diagonals.generate(Board.coordinates_to_index({8, 8}))
+
+      assert [quadrant] = Enum.reject(quadrants, fn quadrant -> Enum.empty?(quadrant) end)
+
+      expected = for position <- 1..7, into: MapSet.new(), do: {position, position}
+
+      assert expected == quadrant
+    end
+
+    test "given starting index at {1, 8}, returns only a single populated quadrant" do
+      assert quadrants = Diagonals.generate(Board.coordinates_to_index({1, 8}))
+
+      assert [quadrant] = Enum.reject(quadrants, fn quadrant -> Enum.empty?(quadrant) end)
+
+      assert MapSet.new([{2, 7}, {3, 6}, {4, 5}, {5, 4}, {6, 3}, {7, 2}, {8, 1}]) == quadrant
+    end
+
+    test "given starting index at {8, 1}, returns only a single populated quadrant" do
+      assert quadrants = Diagonals.generate(Board.coordinates_to_index({8, 1}))
+
+      assert [quadrant] = Enum.reject(quadrants, fn quadrant -> Enum.empty?(quadrant) end)
+
+      assert MapSet.new([{7, 2}, {6, 3}, {5, 4}, {4, 5}, {3, 6}, {2, 7}, {1, 8}]) == quadrant
+    end
   end
 end

--- a/test/chess/moves/generators/diagonals_test.exs
+++ b/test/chess/moves/generators/diagonals_test.exs
@@ -15,5 +15,15 @@ defmodule Chess.Moves.Generators.DiagonalsTest do
       assert MapSet.new([{3, 5}, {2, 6}, {1, 7}]) == quadrant_3
       assert MapSet.new([{5, 5}, {6, 6}, {7, 7}, {8, 8}]) == quadrant_4
     end
+
+    test "given starting index at {1, 1}, returns only a single populated quadrant" do
+      assert quadrants = Diagonals.generate(Board.coordinates_to_index({1, 1}))
+
+      assert [quadrant] = Enum.reject(quadrants, fn quadrant -> Enum.empty?(quadrant) end)
+
+      expected = for position <- 2..8, into: MapSet.new(), do: {position, position}
+
+      assert expected == quadrant
+    end
   end
 end

--- a/test/chess/moves/generators/diagonals_test.exs
+++ b/test/chess/moves/generators/diagonals_test.exs
@@ -8,8 +8,12 @@ defmodule Chess.Moves.Generators.DiagonalsTest do
     test "given starting index at {4, 4}, returns a list of sets along all diagonals" do
       starting_index = Board.coordinates_to_index({4, 4})
 
-      assert [_quadrant_1, _quadrant_2, _quadrant_3, _quadrant_4] =
-               Diagonals.generate(starting_index)
+      assert [quadrant_1, quadrant_2, quadrant_3, quadrant_4] = Diagonals.generate(starting_index)
+
+      assert MapSet.new([{3, 3}, {2, 2}, {1, 1}]) == quadrant_1
+      assert MapSet.new([{5, 3}, {6, 2}, {7, 1}]) == quadrant_2
+      assert MapSet.new([{3, 5}, {2, 6}, {1, 7}]) == quadrant_3
+      assert MapSet.new([{5, 5}, {6, 6}, {7, 7}, {8, 8}]) == quadrant_4
     end
   end
 end


### PR DESCRIPTION
Extracts diagonal move generation based on a starting index into its own module. Closes #11 