### PR TITLE
Inspect/board

### DIFF
--- a/lib/chess/board/inspect.ex
+++ b/lib/chess/board/inspect.ex
@@ -1,0 +1,37 @@
+defimpl Inspect, for: Chess.Board do
+  import Inspect.Algebra
+
+  alias Chess.Piece
+
+  def inspect(board, opts) do
+    as_list = :array.to_list(board.grid)
+
+    grid =
+      as_list
+      |> Enum.reduce([], fn piece, grid ->
+        doc =
+          case piece do
+            nil ->
+              string(" x ")
+
+            %Piece{} ->
+              string(inspect(piece))
+          end
+
+        [doc | grid]
+      end)
+      |> Enum.reverse()
+      |> Enum.chunk_every(8)
+      |> Enum.map(&concat/1)
+
+    container_doc(
+      "#Board<\n",
+      grid,
+      string("\n>"),
+      opts,
+      fn doc, _opts -> doc end,
+      separator: "\n",
+      break: :strict
+    )
+  end
+end

--- a/lib/chess/pieces/piece.ex
+++ b/lib/chess/pieces/piece.ex
@@ -74,7 +74,6 @@ defmodule Chess.Piece do
     alias Chess.Piece
     alias Chess.Pieces.{Bishop, King, Knight, Pawn, Queen, Rook}
 
-    def to_string(nil), do: "x"
     def to_string(%Piece{type: Pawn, color: color}), do: "#{color_to_string(color)} P"
     def to_string(%Piece{type: Rook, color: color}), do: "#{color_to_string(color)} R"
     def to_string(%Piece{type: Knight, color: color}), do: "#{color_to_string(color)} K"

--- a/lib/chess/pieces/piece.ex
+++ b/lib/chess/pieces/piece.ex
@@ -69,4 +69,20 @@ defmodule Chess.Piece do
       i when i in @king_indices -> King
     end
   end
+
+  defimpl String.Chars do
+    alias Chess.Piece
+    alias Chess.Pieces.{Bishop, King, Knight, Pawn, Queen, Rook}
+
+    def to_string(nil), do: "x"
+    def to_string(%Piece{type: Pawn, color: color}), do: "#{color_to_string(color)} P"
+    def to_string(%Piece{type: Rook, color: color}), do: "#{color_to_string(color)} R"
+    def to_string(%Piece{type: Knight, color: color}), do: "#{color_to_string(color)} K"
+    def to_string(%Piece{type: Bishop, color: color}), do: "#{color_to_string(color)} B"
+    def to_string(%Piece{type: Queen, color: color}), do: "#{color_to_string(color)} Q"
+    def to_string(%Piece{type: King, color: color}), do: "#{color_to_string(color)} 👑"
+
+    defp color_to_string(:white), do: "⬜"
+    defp color_to_string(:black), do: "⬛"
+  end
 end

--- a/lib/chess/pieces/piece.ex
+++ b/lib/chess/pieces/piece.ex
@@ -74,14 +74,27 @@ defmodule Chess.Piece do
     alias Chess.Piece
     alias Chess.Pieces.{Bishop, King, Knight, Pawn, Queen, Rook}
 
-    def to_string(%Piece{type: Pawn, color: color}), do: "#{color_to_string(color)} P"
-    def to_string(%Piece{type: Rook, color: color}), do: "#{color_to_string(color)} R"
-    def to_string(%Piece{type: Knight, color: color}), do: "#{color_to_string(color)} K"
-    def to_string(%Piece{type: Bishop, color: color}), do: "#{color_to_string(color)} B"
-    def to_string(%Piece{type: Queen, color: color}), do: "#{color_to_string(color)} Q"
-    def to_string(%Piece{type: King, color: color}), do: "#{color_to_string(color)} 👑"
+    def to_string(%Piece{type: Pawn}), do: " ♟️ "
+    def to_string(%Piece{type: Rook}), do: " ♜ "
+    def to_string(%Piece{type: Knight}), do: " ♞ "
+    def to_string(%Piece{type: Bishop}), do: " ♝ "
+    def to_string(%Piece{type: Queen}), do: " ♛ "
+    def to_string(%Piece{type: King}), do: " ♚ "
+  end
 
-    defp color_to_string(:white), do: "⬜"
-    defp color_to_string(:black), do: "⬛"
+  defimpl Inspect do
+    import Inspect.Algebra
+    alias Chess.Piece
+
+    @black "\e[1;40;37m"
+    @white "\e[1;47;37m"
+
+    def inspect(%Piece{color: :white} = piece, _opts) do
+      color(string(to_string(piece)), :binary, Inspect.Opts.new(syntax_colors: [binary: @white]))
+    end
+
+    def inspect(%Piece{color: :black} = piece, _opts) do
+      color(string(to_string(piece)), :binary, Inspect.Opts.new(syntax_colors: [binary: @black]))
+    end
   end
 end

--- a/test/chess/board/board_test.exs
+++ b/test/chess/board/board_test.exs
@@ -159,4 +159,13 @@ defmodule Chess.BoardTest do
       assert {nil, ^board} = Board.pop(board, -1)
     end
   end
+
+  describe "Inspect protocol" do
+    test "renders a custom representation of the board" do
+      expected_representation =
+        "#Board<\n\e[1;40;37m ♜ \e[0m\e[1;40;37m ♞ \e[0m\e[1;40;37m ♝ \e[0m\e[1;40;37m ♛ \e[0m\e[1;40;37m ♚ \e[0m\e[1;40;37m ♝ \e[0m\e[1;40;37m ♞ \e[0m\e[1;40;37m ♜ \e[0m\n \e[1;40;37m ♟️ \e[0m\e[1;40;37m ♟️ \e[0m\e[1;40;37m ♟️ \e[0m\e[1;40;37m ♟️ \e[0m\e[1;40;37m ♟️ \e[0m\e[1;40;37m ♟️ \e[0m\e[1;40;37m ♟️ \e[0m\e[1;40;37m ♟️ \e[0m\n  x  x  x  x  x  x  x  x \n  x  x  x  x  x  x  x  x \n  x  x  x  x  x  x  x  x \n  x  x  x  x  x  x  x  x \n \e[1;47;37m ♟️ \e[0m\e[1;47;37m ♟️ \e[0m\e[1;47;37m ♟️ \e[0m\e[1;47;37m ♟️ \e[0m\e[1;47;37m ♟️ \e[0m\e[1;47;37m ♟️ \e[0m\e[1;47;37m ♟️ \e[0m\e[1;47;37m ♟️ \e[0m\n \e[1;47;37m ♜ \e[0m\e[1;47;37m ♞ \e[0m\e[1;47;37m ♝ \e[0m\e[1;47;37m ♛ \e[0m\e[1;47;37m ♚ \e[0m\e[1;47;37m ♝ \e[0m\e[1;47;37m ♞ \e[0m\e[1;47;37m ♜ \e[0m\n>"
+
+      assert expected_representation == inspect(Board.layout())
+    end
+  end
 end

--- a/test/chess/piece_test.exs
+++ b/test/chess/piece_test.exs
@@ -70,44 +70,28 @@ defmodule Chess.PieceTest do
   end
 
   describe "String.Chars" do
-    test "returns '⬜  B' for a white Bishop" do
-      assert "⬜ B" == to_string(%Piece{type: Bishop, color: :white})
+    test "returns ♝ for Bishops" do
+      assert " ♝ " == to_string(%Piece{type: Bishop})
     end
 
-    test "returns '⬛ B' for a black Bishop" do
-      assert "⬛ B" == to_string(%Piece{type: Bishop, color: :black})
+    test "returns  ♟️  for Pawns" do
+      assert " ♟️ " == to_string(%Piece{type: Pawn})
     end
 
-    test "returns '⬜ P' for a white Pawn" do
-      assert "⬜ P" == to_string(%Piece{type: Pawn, color: :white})
+    test "returns  ♜  for Rooks" do
+      assert " ♜ " == to_string(%Piece{type: Rook})
     end
 
-    test "returns '⬛ P' for a black Pawn" do
-      assert "⬛ P" == to_string(%Piece{type: Pawn, color: :black})
+    test "returns  ♞  for Knights" do
+      assert " ♞ " == to_string(%Piece{type: Knight})
     end
 
-    test "returns '⬜ R' for a white Rook" do
-      assert "⬜ R" == to_string(%Piece{type: Rook, color: :white})
+    test "returns  ♛  for Queens" do
+      assert " ♛ " == to_string(%Piece{type: Queen})
     end
 
-    test "returns '⬛ R' for a black Rook" do
-      assert "⬛ R" == to_string(%Piece{type: Rook, color: :black})
-    end
-
-    test "returns '⬜ K' for a white Knight" do
-      assert "⬜ K" == to_string(%Piece{type: Knight, color: :white})
-    end
-
-    test "returns '⬛ K' for a black Knight" do
-      assert "⬛ K" == to_string(%Piece{type: Knight, color: :black})
-    end
-
-    test "returns '⬜ Q' for a white Queen" do
-      assert "⬜ Q" == to_string(%Piece{type: Queen, color: :white})
-    end
-
-    test "returns '⬛ Q' for a black Queen" do
-      assert "⬛ Q" == to_string(%Piece{type: Queen, color: :black})
+    test "returns  ♚  for Kings" do
+      assert " ♚ " == to_string(%Piece{type: King})
     end
   end
 end

--- a/test/chess/piece_test.exs
+++ b/test/chess/piece_test.exs
@@ -94,4 +94,23 @@ defmodule Chess.PieceTest do
       assert " ♚ " == to_string(%Piece{type: King})
     end
   end
+
+  describe "Inspect protocol" do
+    @opening_ansi_code_white "\e[1;47;37m"
+    @opening_ansi_code_black "\e[1;40;37m"
+    @closing_ansi_code "\e[0m"
+    test "returns custom representation of chess pieces with white color" do
+      piece = %Piece{type: Enum.random([Bishop, Pawn, Rook, Knight, Queen, King]), color: :white}
+
+      assert "#{@opening_ansi_code_white}#{to_string(piece)}#{@closing_ansi_code}" ==
+               inspect(piece)
+    end
+
+    test "returns customer representation of chess pieces with black color" do
+      piece = %Piece{type: Enum.random([Bishop, Pawn, Rook, Knight, Queen, King]), color: :black}
+
+      assert "#{@opening_ansi_code_black}#{to_string(piece)}#{@closing_ansi_code}" ==
+               inspect(piece)
+    end
+  end
 end

--- a/test/chess/piece_test.exs
+++ b/test/chess/piece_test.exs
@@ -68,4 +68,46 @@ defmodule Chess.PieceTest do
       end
     end
   end
+
+  describe "String.Chars" do
+    test "returns '⬜  B' for a white Bishop" do
+      assert "⬜ B" == to_string(%Piece{type: Bishop, color: :white})
+    end
+
+    test "returns '⬛ B' for a black Bishop" do
+      assert "⬛ B" == to_string(%Piece{type: Bishop, color: :black})
+    end
+
+    test "returns '⬜ P' for a white Pawn" do
+      assert "⬜ P" == to_string(%Piece{type: Pawn, color: :white})
+    end
+
+    test "returns '⬛ P' for a black Pawn" do
+      assert "⬛ P" == to_string(%Piece{type: Pawn, color: :black})
+    end
+
+    test "returns '⬜ R' for a white Rook" do
+      assert "⬜ R" == to_string(%Piece{type: Rook, color: :white})
+    end
+
+    test "returns '⬛ R' for a black Rook" do
+      assert "⬛ R" == to_string(%Piece{type: Rook, color: :black})
+    end
+
+    test "returns '⬜ K' for a white Knight" do
+      assert "⬜ K" == to_string(%Piece{type: Knight, color: :white})
+    end
+
+    test "returns '⬛ K' for a black Knight" do
+      assert "⬛ K" == to_string(%Piece{type: Knight, color: :black})
+    end
+
+    test "returns '⬜ Q' for a white Queen" do
+      assert "⬜ Q" == to_string(%Piece{type: Queen, color: :white})
+    end
+
+    test "returns '⬛ Q' for a black Queen" do
+      assert "⬛ Q" == to_string(%Piece{type: Queen, color: :black})
+    end
+  end
 end


### PR DESCRIPTION
Introduces a custom representation of a `Chess.Board` struct, along with representations for `Chess.Piece` structs, by defining the `Inspect` protocol for each. Closes #12 