### PR TITLE
Bitboards/initialization

### DIFF
--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -39,11 +39,11 @@ defmodule Chess.Boards.BitBoard do
     {:white_bishops, 36},
     {:white_king, 8},
     {:white_knights, 66},
-    {:white_pawns, 65280},
+    {:white_pawns, 65_280},
     {:white_queens, 16},
     {:white_rooks, 129},
     {:black_composite, 18_446_462_598_732_840_960},
-    {:white_composite, 65535}
+    {:white_composite, 65_535}
   ]
 
   @atomics_offset 1

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -41,7 +41,9 @@ defmodule Chess.Boards.BitBoard do
     {:white_knights, 66},
     {:white_pawns, 65280},
     {:white_queens, 16},
-    {:white_rooks, 129}
+    {:white_rooks, 129},
+    {:black_composite, 18_446_462_598_732_840_960},
+    {:white_composite, 65535}
   ]
 
   @atomics_offset 1

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -69,8 +69,8 @@ defmodule Chess.Boards.BitBoard do
   mainly for inspecting the state of a bitboard in
   a way that is human-readable at a glance.
   """
-  @spec to_list(t(), bitboard()) :: list(list(0 | 1))
-  def to_list(bitboard, bitboard_type \\ :composite) do
+  @spec to_grid(t(), bitboard()) :: list(list(0 | 1))
+  def to_grid(bitboard, bitboard_type \\ :composite) do
     bitboard.ref
     |> :atomics.get(@bitboards[bitboard_type])
     |> Integer.digits(2)

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -69,7 +69,7 @@ defmodule Chess.Boards.BitBoard do
   mainly for inspecting the state of a bitboard in
   a way that is human-readable at a glance.
   """
-  @spec to_list(t(), bitboard()) :: list()
+  @spec to_list(t(), bitboard()) :: list(list(0 | 1))
   def to_list(bitboard, bitboard_type \\ :composite) do
     bitboard.ref
     |> :atomics.get(@bitboards[bitboard_type])

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -8,43 +8,85 @@ defmodule Chess.Boards.BitBoard do
   concurrent access into an array of 64-bit integers.
   https://www.erlang.org/doc/man/atomics.html
   """
-  use Bitwise
-
   defstruct [:ref]
 
   @opaque bitboards() :: :atomics.atomics_ref()
   @type position() :: non_neg_integer()
   @type t() :: %__MODULE__{ref: bitboards()}
-  @type bitboard() :: :positions
+  @type bitboard() ::
+          :composite
+          | :white_pawns
+          | :white_rooks
+          | :white_knights
+          | :white_bishops
+          | :white_queens
+          | :white_king
+          | :black_pawns
+          | :black_rooks
+          | :black_knights
+          | :black_bishops
+          | :black_queens
+          | :black_king
 
-  @positions_index 1
-  @bitboards %{positions: @positions_index}
-  @bitboard_count 1
+  @initial_boards [
+    {:composite, 18_446_462_598_732_906_495},
+    {:black_bishops, 2_594_073_385_365_405_696},
+    {:black_king, 576_460_752_303_423_488},
+    {:black_knights, 4_755_801_206_503_243_776},
+    {:black_pawns, 71_776_119_061_217_280},
+    {:black_queens, 1_152_921_504_606_846_976},
+    {:black_rooks, 9_295_429_630_892_703_744},
+    {:white_bishops, 36},
+    {:white_king, 8},
+    {:white_knights, 66},
+    {:white_pawns, 65280},
+    {:white_queens, 16},
+    {:white_rooks, 129}
+  ]
+
+  @atomics_offset 1
+
+  @bitboards @initial_boards
+             |> Enum.with_index(@atomics_offset)
+             |> Enum.map(fn {{key, _}, index} -> {key, index} end)
 
   @spec new() :: t()
   def new do
-    bitboards = :atomics.new(@bitboard_count, signed: false)
+    bitboards = :atomics.new(length(@bitboards), signed: false)
 
-    _ = initialize_positions(bitboards)
+    for {bitboard_type, bitboard_index} <- @bitboards do
+      :atomics.put(bitboards, bitboard_index, @initial_boards[bitboard_type])
+    end
 
     %__MODULE__{ref: bitboards}
   end
 
+  @doc """
+  Returns an 8x8 grid representation of a given
+  bitboard. If the bitboard does not take up a full
+  64 bits, the representation is padded with 0s to
+  create a full 8x8 grid. This function is intended
+  mainly for inspecting the state of a bitboard in
+  a way that is human-readable at a glance.
+  """
   @spec to_list(t(), bitboard()) :: list()
-  def to_list(bitboard, bitboard_type \\ :positions) do
+  def to_list(bitboard, bitboard_type \\ :composite) do
     bitboard.ref
     |> :atomics.get(@bitboards[bitboard_type])
     |> Integer.digits(2)
+    |> then(&with_padding/1)
     |> Enum.chunk_every(8)
   end
 
-  @spec initialize_positions(bitboards()) :: list(:ok)
-  defp initialize_positions(bitboards) do
-    for shift <- Enum.concat(0..15, 48..63) do
-      1
-      |> bsl(shift)
-      |> bor(:atomics.get(bitboards, @positions_index))
-      |> then(fn bitboard -> :atomics.put(bitboards, @positions_index, bitboard) end)
+  @spec with_padding(list(0 | 1)) :: list(0 | 1)
+  defp with_padding(board) do
+    board_length = Enum.count(board)
+
+    zeros = fn _ -> 0 end
+
+    case board_length < 64 do
+      true -> Enum.concat(Enum.map(board_length..63, zeros), board)
+      false -> board
     end
   end
 end

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -66,8 +66,8 @@ defmodule Chess.Boards.BitBoard do
   bitboard. If the bitboard does not take up a full
   64 bits, the representation is padded with 0s to
   create a full 8x8 grid. This function is intended
-  mainly for inspecting the state of a bitboard in
-  a way that is human-readable at a glance.
+  mainly for debugging and inspecting the state of
+  a bitboard in a way that is human-readable at a glance.
   """
   @spec to_grid(t(), bitboard()) :: list(list(0 | 1))
   def to_grid(bitboard, bitboard_type \\ :composite) do

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -27,5 +27,185 @@ defmodule Chess.Boards.BitBoardTest do
                [1, 1, 1, 1, 1, 1, 1, 1]
              ] == BitBoard.to_list(bitboard, :composite)
     end
+
+    test "returns an 8x8 representation of the bitboard for black pawns" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [1, 1, 1, 1, 1, 1, 1, 1],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_list(bitboard, :black_pawns)
+    end
+
+    test "returns an 8x8 representation of the bitboard for black knights" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 1, 0, 0, 0, 0, 1, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_list(bitboard, :black_knights)
+    end
+
+    test "returns an 8x8 representation of the bitboard for black rooks" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [1, 0, 0, 0, 0, 0, 0, 1],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_list(bitboard, :black_rooks)
+    end
+
+    test "returns an 8x8 representation of the bitboard for black bishops" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 1, 0, 0, 1, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_list(bitboard, :black_bishops)
+    end
+
+    test "returns an 8x8 representation of the bitboard for the black queen" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 0, 1, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_list(bitboard, :black_queens)
+    end
+
+    test "returns an 8x8 representation of the bitboard for the black king" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 0, 0, 1, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_list(bitboard, :black_king)
+    end
+
+    test "returns an 8x8 representation of the bitboard for white pawns" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [1, 1, 1, 1, 1, 1, 1, 1],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_list(bitboard, :white_pawns)
+    end
+
+    test "returns an 8x8 representation of the bitboard for white knights" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 1, 0, 0, 0, 0, 1, 0]
+             ] == BitBoard.to_list(bitboard, :white_knights)
+    end
+
+    test "returns an 8x8 representation of the bitboard for white rooks" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [1, 0, 0, 0, 0, 0, 0, 1]
+             ] == BitBoard.to_list(bitboard, :white_rooks)
+    end
+
+    test "returns an 8x8 representation of the bitboard for white bishops" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 1, 0, 0, 1, 0, 0]
+             ] == BitBoard.to_list(bitboard, :white_bishops)
+    end
+
+    test "returns an 8x8 representation of the bitboard for the white queen" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 1, 0, 0, 0, 0]
+             ] == BitBoard.to_list(bitboard, :white_queens)
+    end
+
+    test "returns an 8x8 representation of the bitboard for the white king" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 1, 0, 0, 0]
+             ] == BitBoard.to_list(bitboard, :white_king)
+    end
   end
 end

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -13,7 +13,7 @@ defmodule Chess.Boards.BitBoardTest do
   end
 
   describe "to_list/2" do
-    test "returns an 8x8 list representation of the bitboard" do
+    test "returns an 8x8 list representation of the composite bitboard" do
       bitboard = BitBoard.new()
 
       assert [
@@ -25,7 +25,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [1, 1, 1, 1, 1, 1, 1, 1],
                [1, 1, 1, 1, 1, 1, 1, 1]
-             ] == BitBoard.to_list(bitboard, :positions)
+             ] == BitBoard.to_list(bitboard, :composite)
     end
   end
 end

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -207,5 +207,35 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 1, 0, 0, 0]
              ] == BitBoard.to_grid(bitboard, :white_king)
     end
+
+    test "returns an 8x8 representation of the bitboard for the black composite position" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [1, 1, 1, 1, 1, 1, 1, 1],
+               [1, 1, 1, 1, 1, 1, 1, 1],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_grid(bitboard, :black_composite)
+    end
+
+    test "returns an 8x8 representation of the bitboard for the white composite position" do
+      bitboard = BitBoard.new()
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [1, 1, 1, 1, 1, 1, 1, 1],
+               [1, 1, 1, 1, 1, 1, 1, 1]
+             ] == BitBoard.to_grid(bitboard, :white_composite)
+    end
   end
 end

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -12,7 +12,7 @@ defmodule Chess.Boards.BitBoardTest do
     end
   end
 
-  describe "to_list/2" do
+  describe "to_grid/2" do
     test "returns an 8x8 list representation of the composite bitboard" do
       bitboard = BitBoard.new()
 
@@ -25,7 +25,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [1, 1, 1, 1, 1, 1, 1, 1],
                [1, 1, 1, 1, 1, 1, 1, 1]
-             ] == BitBoard.to_list(bitboard, :composite)
+             ] == BitBoard.to_grid(bitboard, :composite)
     end
 
     test "returns an 8x8 representation of the bitboard for black pawns" do
@@ -40,7 +40,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_list(bitboard, :black_pawns)
+             ] == BitBoard.to_grid(bitboard, :black_pawns)
     end
 
     test "returns an 8x8 representation of the bitboard for black knights" do
@@ -55,7 +55,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_list(bitboard, :black_knights)
+             ] == BitBoard.to_grid(bitboard, :black_knights)
     end
 
     test "returns an 8x8 representation of the bitboard for black rooks" do
@@ -70,7 +70,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_list(bitboard, :black_rooks)
+             ] == BitBoard.to_grid(bitboard, :black_rooks)
     end
 
     test "returns an 8x8 representation of the bitboard for black bishops" do
@@ -85,7 +85,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_list(bitboard, :black_bishops)
+             ] == BitBoard.to_grid(bitboard, :black_bishops)
     end
 
     test "returns an 8x8 representation of the bitboard for the black queen" do
@@ -100,7 +100,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_list(bitboard, :black_queens)
+             ] == BitBoard.to_grid(bitboard, :black_queens)
     end
 
     test "returns an 8x8 representation of the bitboard for the black king" do
@@ -115,7 +115,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_list(bitboard, :black_king)
+             ] == BitBoard.to_grid(bitboard, :black_king)
     end
 
     test "returns an 8x8 representation of the bitboard for white pawns" do
@@ -130,7 +130,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [1, 1, 1, 1, 1, 1, 1, 1],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_list(bitboard, :white_pawns)
+             ] == BitBoard.to_grid(bitboard, :white_pawns)
     end
 
     test "returns an 8x8 representation of the bitboard for white knights" do
@@ -145,7 +145,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 1, 0, 0, 0, 0, 1, 0]
-             ] == BitBoard.to_list(bitboard, :white_knights)
+             ] == BitBoard.to_grid(bitboard, :white_knights)
     end
 
     test "returns an 8x8 representation of the bitboard for white rooks" do
@@ -160,7 +160,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [1, 0, 0, 0, 0, 0, 0, 1]
-             ] == BitBoard.to_list(bitboard, :white_rooks)
+             ] == BitBoard.to_grid(bitboard, :white_rooks)
     end
 
     test "returns an 8x8 representation of the bitboard for white bishops" do
@@ -175,7 +175,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 1, 0, 0, 1, 0, 0]
-             ] == BitBoard.to_list(bitboard, :white_bishops)
+             ] == BitBoard.to_grid(bitboard, :white_bishops)
     end
 
     test "returns an 8x8 representation of the bitboard for the white queen" do
@@ -190,7 +190,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 1, 0, 0, 0, 0]
-             ] == BitBoard.to_list(bitboard, :white_queens)
+             ] == BitBoard.to_grid(bitboard, :white_queens)
     end
 
     test "returns an 8x8 representation of the bitboard for the white king" do
@@ -205,7 +205,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 1, 0, 0, 0]
-             ] == BitBoard.to_list(bitboard, :white_king)
+             ] == BitBoard.to_grid(bitboard, :white_king)
     end
   end
 end


### PR DESCRIPTION
This PR sets up initialization of bitboard positions, i.e., bitboards that represent the starting positions of all pieces in a standard game of chess. 

There are 3 composite bitboards to go along with the piece-specific bitboards: `black_composite`, representing the starting position of all black pieces, `white_composite`, representing the starting position of all white pieces, and `composite`, which represents the starting position of all pieces for a game.

This, in general, is a good starting spot for a game state representation. 