### PR TITLE
Chess/encode moves

### DIFF
--- a/lib/chess/board/bitboards/move.ex
+++ b/lib/chess/board/bitboards/move.ex
@@ -39,6 +39,7 @@ defmodule Chess.Bitboards.Move do
   14 -> rook promotion capture
   15 -> queen promotion capture
   """
+  use Bitwise
 
   defstruct [:from, :to, :flag]
 
@@ -97,7 +98,7 @@ defmodule Chess.Bitboards.Move do
 
   @typedoc """
   An encoded move is a 16-bit integer, which means it has
-  a decimal-based integer value of 0..256.
+  a decimal-based integer value of 0..65536.
 
   The first 6 bits of the integer represent the origin square
   from which a move is made.
@@ -109,13 +110,19 @@ defmodule Chess.Bitboards.Move do
   the type of move, captures, promotions, etc. See the docs on
   `t:flag/0` for more information.
   """
-  @type encoded() :: 0..256
+  @type encoded() :: 0..65536
 
   @spec flags() :: list(flag())
   def flags, do: Map.keys(@flag_codes)
 
+  @file_to_value ?a..?h |> Enum.with_index() |> Map.new(fn {k, v} -> {<<k>>, v} end)
+
   @spec encode(t()) :: encoded()
-  def encode(move) do
-    :nope
+  def encode(%__MODULE__{from: {from_file, from_rank}, to: {to_file, to_rank}, flag: flag}) do
+    @file_to_value[from_file]
+    |> bor((from_rank - 1) <<< 3)
+    |> bor(@file_to_value[to_file] <<< 6)
+    |> bor((to_rank - 1) <<< 9)
+    |> bor(@flag_codes[flag] <<< 12)
   end
 end

--- a/lib/chess/board/bitboards/move.ex
+++ b/lib/chess/board/bitboards/move.ex
@@ -39,4 +39,40 @@ defmodule Chess.Bitboards.Move do
   14 -> rook promotion capture
   15 -> queen promotion capture
   """
+
+  @flag_codes %{
+    quiet: 0,
+    double_pawn_push: 1,
+    king_castle: 2,
+    queen_castle: 3,
+    captures: 4,
+    en_passant_captures: 5,
+    knight_promotion: 8,
+    bishop_promotion: 9,
+    rook_promotion: 10,
+    queen_promotion: 11,
+    knight_promotion_capture: 12,
+    bishop_promotion_capture: 13,
+    rook_promotion_capture: 14,
+    queen_promotion_capture: 15
+  }
+
+  @type flag() ::
+          :quiet
+          | :double_pawn_push
+          | :king_castle
+          | :queen_castle
+          | :captures
+          | :en_passant_captures
+          | :knight_promotion
+          | :bishop_promotion
+          | :rook_promotion
+          | :queen_promotion
+          | :knight_promotion_capture
+          | :bishop_promotion_capture
+          | :rook_promotion_capture
+          | :queen_promotion_capture
+
+  @spec flags() :: list(flag())
+  def flags, do: Map.keys(@flag_codes)
 end

--- a/lib/chess/board/bitboards/move.ex
+++ b/lib/chess/board/bitboards/move.ex
@@ -40,6 +40,8 @@ defmodule Chess.Bitboards.Move do
   15 -> queen promotion capture
   """
 
+  defstruct [:from, :to, :flag]
+
   @flag_codes %{
     quiet: 0,
     double_pawn_push: 1,
@@ -56,6 +58,23 @@ defmodule Chess.Bitboards.Move do
     rook_promotion_capture: 14,
     queen_promotion_capture: 15
   }
+
+  @typedoc """
+  A `coordinate` is a tuple representing the
+  file (the first element of the tuple), which is
+  a string in the range from "a" to "h", and the
+  rank, which is an integer in the range 1..8.
+
+  In chess, a file represents a column along the board,
+  while a rank represent rows on the board.
+  """
+  @type coordinate() :: {String.t(), 1..8}
+
+  @type t() :: %__MODULE__{
+          from: coordinate(),
+          to: coordinate(),
+          flag: flag()
+        }
 
   @typedoc """
   The set of all possible move flags.
@@ -94,4 +113,9 @@ defmodule Chess.Bitboards.Move do
 
   @spec flags() :: list(flag())
   def flags, do: Map.keys(@flag_codes)
+
+  @spec encode(t()) :: encoded()
+  def encode(move) do
+    :nope
+  end
 end

--- a/lib/chess/board/bitboards/move.ex
+++ b/lib/chess/board/bitboards/move.ex
@@ -57,6 +57,9 @@ defmodule Chess.Bitboards.Move do
     queen_promotion_capture: 15
   }
 
+  @typedoc """
+  The set of all possible move flags.
+  """
   @type flag() ::
           :quiet
           | :double_pawn_push
@@ -72,6 +75,22 @@ defmodule Chess.Bitboards.Move do
           | :bishop_promotion_capture
           | :rook_promotion_capture
           | :queen_promotion_capture
+
+  @typedoc """
+  An encoded move is a 16-bit integer, which means it has
+  a decimal-based integer value of 0..256.
+
+  The first 6 bits of the integer represent the origin square
+  from which a move is made.
+
+  The second 6 bits of the integer represent the destination square
+  to which a move is made.
+
+  The remaining 4 bits of the integer represent a flag denoting
+  the type of move, captures, promotions, etc. See the docs on
+  `t:flag/0` for more information.
+  """
+  @type encoded() :: 0..256
 
   @spec flags() :: list(flag())
   def flags, do: Map.keys(@flag_codes)

--- a/lib/chess/board/bitboards/move.ex
+++ b/lib/chess/board/bitboards/move.ex
@@ -1,0 +1,42 @@
+defmodule Chess.Bitboards.Move do
+  @moduledoc """
+  Module for working with encoded chess moves, where
+  moves will be encoded as a series of bits according to
+  the following structure:
+
+  Bits 1..3 -> From file, with file a = 0 and file h = 7;
+  in other words file a = `[0, 0, 0]` while file h = `[1, 1, 1]`
+  in a binary, bitwise representation.
+
+  Bits 4..6 -> From rank, with rank 1 = 0 and rank 8 = 56;
+  in other words, rank 1 = `[0, 0, 0, 0, 0, 0]` and rank 8 =
+  `[1, 1, 1, 0, 0, 0]`.
+
+  Bits 7..9 -> To file, essentially the same as bits 1..3 except
+  each file is left-shifted 6; i.e.:
+  `[0, 0, 0, <from-rank-bits>, <from-file-bits>]` for a move to file a,
+  `[1, 1, 1, <from-rank-bits>, <from-file-bits>]` for a move to file h
+
+  Bits 10..12 -> To rank, essentially the same as bits 4..6 except with
+  each rank left-shifted again by 6; i.e.:
+  `[0, 0, 0, <to-file-bits>, <from-rank-bits>, <from-file-bits>]` for a move to rank 1,
+  `[1, 1, 1, <to-file-bits>, <from-rank-bits>, <from-file-bits>]` for a move to rank 8.
+
+  Bits 13..16 are flags, representing the following:
+
+  0 -> quiet move
+  1 -> double pawn push
+  2 -> king castle
+  3 -> queen castle
+  4 -> captures
+  5 -> en-passant captures
+  8 -> knight promotion
+  9 -> bishop promotion
+  10 -> rook promotion
+  11 -> queen promotion
+  12 -> knight promotion capture
+  13 -> bishop promotion capture
+  14 -> rook promotion capture
+  15 -> queen promotion capture
+  """
+end

--- a/test/chess/board/bitboards/move_test.exs
+++ b/test/chess/board/bitboards/move_test.exs
@@ -1,5 +1,6 @@
 defmodule Chess.Bitboards.MoveTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias Chess.Bitboards.Move
 
@@ -30,6 +31,35 @@ defmodule Chess.Bitboards.MoveTest do
 
              #{inspect(Move.flags())}
              """
+    end
+  end
+
+  describe "encode/1" do
+    property "returns an integer between 0 and 256 for any valid move" do
+      check all(move <- move_generator()) do
+        assert Move.encode(move) in 0..256
+      end
+    end
+  end
+
+  def move_generator() do
+    gen all(
+          from <-
+            StreamData.tuple(
+              {StreamData.string(?a..?h, min_length: 1, max_length: 1), StreamData.integer(1..8)}
+            ),
+          to <-
+            StreamData.tuple(
+              {StreamData.string(?a..?h, min_length: 1, max_length: 1), StreamData.integer(1..8)}
+            ),
+          flag <- StreamData.one_of(Move.flags()),
+          from != to
+        ) do
+      %Move{
+        from: from,
+        to: to,
+        flag: flag
+      }
     end
   end
 end

--- a/test/chess/board/bitboards/move_test.exs
+++ b/test/chess/board/bitboards/move_test.exs
@@ -35,9 +35,9 @@ defmodule Chess.Bitboards.MoveTest do
   end
 
   describe "encode/1" do
-    property "returns an integer between 0 and 256 for any valid move" do
+    property "returns an integer between 0 and 65536 for any valid move" do
       check all(move <- move_generator()) do
-        assert Move.encode(move) in 0..256
+        assert Move.encode(move) in 0..65536
       end
     end
   end
@@ -52,8 +52,7 @@ defmodule Chess.Bitboards.MoveTest do
             StreamData.tuple(
               {StreamData.string(?a..?h, min_length: 1, max_length: 1), StreamData.integer(1..8)}
             ),
-          flag <- StreamData.one_of(Move.flags()),
-          from != to
+          flag <- StreamData.one_of(Move.flags())
         ) do
       %Move{
         from: from,

--- a/test/chess/board/bitboards/move_test.exs
+++ b/test/chess/board/bitboards/move_test.exs
@@ -1,0 +1,35 @@
+defmodule Chess.Bitboards.MoveTest do
+  use ExUnit.Case, async: true
+
+  alias Chess.Bitboards.Move
+
+  describe "flags/0" do
+    test "returns the list of all possible move flags" do
+      expected_flags = ~w(
+        quiet
+        double_pawn_push
+        king_castle
+        queen_castle
+        captures
+        en_passant_captures
+        knight_promotion
+        bishop_promotion
+        rook_promotion
+        queen_promotion
+        knight_promotion_capture
+        bishop_promotion_capture
+        rook_promotion_capture
+        queen_promotion_capture
+      )a
+
+      assert MapSet.equal?(MapSet.new(expected_flags), MapSet.new(Move.flags())),
+             """
+             Expected the set of expected flags:
+             #{inspect(expected_flags)}
+             to be exactly equal to the set of flags returned from `Move.flags/0`:
+
+             #{inspect(Move.flags())}
+             """
+    end
+  end
+end


### PR DESCRIPTION
Encodes a move struct into a 16-bit integer, where bits:

1-3 --> The `from` file of the move
4-6 --> The `from` rank of the move
7-9 --> The `to` file of the move
10-12 --> The `to` rank of the move
13-16 --> Special flags denoting types of move, capture, promotion, etc.

Closes #37 