### PR TITLE
Bitboards/get_board

### DIFF
--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -27,6 +27,8 @@ defmodule Chess.Boards.BitBoard do
           | :black_bishops
           | :black_queens
           | :black_king
+          | :black_composite
+          | :white_composite
 
   @initial_boards [
     {:composite, 18_446_462_598_732_906_495},
@@ -52,6 +54,8 @@ defmodule Chess.Boards.BitBoard do
              |> Enum.with_index(@atomics_offset)
              |> Enum.map(fn {{key, _}, index} -> {key, index} end)
 
+  @bitboard_types Enum.map(@bitboards, fn {type, _} -> type end)
+
   @spec new() :: t()
   def new do
     bitboards = :atomics.new(length(@bitboards), signed: false)
@@ -62,6 +66,13 @@ defmodule Chess.Boards.BitBoard do
 
     %__MODULE__{ref: bitboards}
   end
+
+  @doc """
+  Returns the list off all different bitboard types that are
+  stored in a Bitboard.t() representation.
+  """
+  @spec list_types() :: list(bitboard())
+  def list_types, do: @bitboard_types
 
   @doc """
   Returns an 8x8 grid representation of a given

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -75,6 +75,23 @@ defmodule Chess.Boards.BitBoard do
   def list_types, do: @bitboard_types
 
   @doc """
+  Returns a keyword list that gives the initial state of each individual
+  bitboard type. Keys are the type of bitboards, values are the initial state
+  as an integer.
+  """
+  @spec initial_states() :: Keyword.t()
+  def initial_states, do: @initial_boards
+
+  @doc """
+  Returns the specific bitboard denoted by `bitboard_type`
+  stored within the `BitBoard.t/0` struct.
+  """
+  @spec get(t(), bitboard()) :: non_neg_integer()
+  def get(bitboard, type) do
+    :atomics.get(bitboard.ref, @bitboards[type])
+  end
+
+  @doc """
   Returns an 8x8 grid representation of a given
   bitboard. If the bitboard does not take up a full
   64 bits, the representation is padded with 0s to

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -99,10 +99,9 @@ defmodule Chess.Boards.BitBoard do
   mainly for debugging and inspecting the state of
   a bitboard in a way that is human-readable at a glance.
   """
-  @spec to_grid(t(), bitboard()) :: list(list(0 | 1))
-  def to_grid(bitboard, bitboard_type \\ :composite) do
-    bitboard.ref
-    |> :atomics.get(@bitboards[bitboard_type])
+  @spec to_grid(non_neg_integer()) :: list(list(0 | 1))
+  def to_grid(bitboard) do
+    bitboard
     |> Integer.digits(2)
     |> then(&with_padding/1)
     |> Enum.chunk_every(8)

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -1,5 +1,5 @@
 defmodule Chess.Boards.BitBoardTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Chess.Boards.BitBoard
 
@@ -51,7 +51,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [1, 1, 1, 1, 1, 1, 1, 1],
                [1, 1, 1, 1, 1, 1, 1, 1]
-             ] == BitBoard.to_grid(bitboard, :composite)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :composite))
     end
 
     test "returns an 8x8 representation of the bitboard for black pawns" do
@@ -66,7 +66,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :black_pawns)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :black_pawns))
     end
 
     test "returns an 8x8 representation of the bitboard for black knights" do
@@ -81,7 +81,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :black_knights)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :black_knights))
     end
 
     test "returns an 8x8 representation of the bitboard for black rooks" do
@@ -96,7 +96,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :black_rooks)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :black_rooks))
     end
 
     test "returns an 8x8 representation of the bitboard for black bishops" do
@@ -111,7 +111,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :black_bishops)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :black_bishops))
     end
 
     test "returns an 8x8 representation of the bitboard for the black queen" do
@@ -126,7 +126,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :black_queens)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :black_queens))
     end
 
     test "returns an 8x8 representation of the bitboard for the black king" do
@@ -141,7 +141,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :black_king)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :black_king))
     end
 
     test "returns an 8x8 representation of the bitboard for white pawns" do
@@ -156,7 +156,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [1, 1, 1, 1, 1, 1, 1, 1],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :white_pawns)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :white_pawns))
     end
 
     test "returns an 8x8 representation of the bitboard for white knights" do
@@ -171,7 +171,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 1, 0, 0, 0, 0, 1, 0]
-             ] == BitBoard.to_grid(bitboard, :white_knights)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :white_knights))
     end
 
     test "returns an 8x8 representation of the bitboard for white rooks" do
@@ -186,7 +186,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [1, 0, 0, 0, 0, 0, 0, 1]
-             ] == BitBoard.to_grid(bitboard, :white_rooks)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :white_rooks))
     end
 
     test "returns an 8x8 representation of the bitboard for white bishops" do
@@ -201,7 +201,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 1, 0, 0, 1, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :white_bishops)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :white_bishops))
     end
 
     test "returns an 8x8 representation of the bitboard for the white queen" do
@@ -216,7 +216,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 1, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :white_queens)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :white_queens))
     end
 
     test "returns an 8x8 representation of the bitboard for the white king" do
@@ -231,7 +231,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 1, 0, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :white_king)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :white_king))
     end
 
     test "returns an 8x8 representation of the bitboard for the black composite position" do
@@ -246,7 +246,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(bitboard, :black_composite)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :black_composite))
     end
 
     test "returns an 8x8 representation of the bitboard for the white composite position" do
@@ -261,7 +261,7 @@ defmodule Chess.Boards.BitBoardTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [1, 1, 1, 1, 1, 1, 1, 1],
                [1, 1, 1, 1, 1, 1, 1, 1]
-             ] == BitBoard.to_grid(bitboard, :white_composite)
+             ] == BitBoard.to_grid(BitBoard.get(bitboard, :white_composite))
     end
   end
 end

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -12,6 +12,23 @@ defmodule Chess.Boards.BitBoardTest do
     end
   end
 
+  describe "list_types/0" do
+    test "returns the list of all bitboard types" do
+      expected_type_set =
+        MapSet.new(
+          ~w(composite black_composite white_composite white_pawns white_rooks white_knights white_bishops white_queens white_king black_pawns black_rooks black_knights black_bishops black_queens black_king)a
+        )
+
+      actual_set = MapSet.new(BitBoard.list_types())
+
+      assert MapSet.equal?(actual_set, expected_type_set), """
+      Expected set of Bitboard types to equal expected set.
+      Actual: #{inspect(actual_set)}
+      Expected: #{inspect(expected_type_set)}
+      """
+    end
+  end
+
   describe "to_grid/2" do
     test "returns an 8x8 list representation of the composite bitboard" do
       bitboard = BitBoard.new()

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -29,6 +29,15 @@ defmodule Chess.Boards.BitBoardTest do
     end
   end
 
+  describe "get/2" do
+    for bitboard_type <- BitBoard.list_types() do
+      test "returns bitboard when given #{bitboard_type}" do
+        assert BitBoard.initial_states()[unquote(bitboard_type)] ==
+                 BitBoard.get(BitBoard.new(), unquote(bitboard_type))
+      end
+    end
+  end
+
   describe "to_grid/2" do
     test "returns an 8x8 list representation of the composite bitboard" do
       bitboard = BitBoard.new()


### PR DESCRIPTION
Adds a few new utility functions to the BitBoard module to get the state of specific bitboards within the array of all bitboards contained in a `Bitboard.t/0` ref.