### PR TITLE
Basic pawn pushes

### DIFF
--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -13,6 +13,12 @@ defmodule Chess.Boards.BitBoard do
   @opaque bitboards() :: :atomics.atomics_ref()
   @type position() :: non_neg_integer()
   @type t() :: %__MODULE__{ref: bitboards()}
+  @typedoc """
+  A t:bitboard/0 is specifically a 64-bit integer
+  that represents one component or composite of
+  an entire chess game bitboard representation.
+  """
+  @type bitboard() :: non_neg_integer()
   @type bitboard_type() ::
           :composite
           | :white_pawns

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -13,7 +13,7 @@ defmodule Chess.Boards.BitBoard do
   @opaque bitboards() :: :atomics.atomics_ref()
   @type position() :: non_neg_integer()
   @type t() :: %__MODULE__{ref: bitboards()}
-  @type bitboard() ::
+  @type bitboard_type() ::
           :composite
           | :white_pawns
           | :white_rooks
@@ -71,7 +71,7 @@ defmodule Chess.Boards.BitBoard do
   Returns the list off all different bitboard types that are
   stored in a Bitboard.t() representation.
   """
-  @spec list_types() :: list(bitboard())
+  @spec list_types() :: list(bitboard_type())
   def list_types, do: @bitboard_types
 
   @doc """
@@ -86,7 +86,7 @@ defmodule Chess.Boards.BitBoard do
   Returns the specific bitboard denoted by `bitboard_type`
   stored within the `BitBoard.t/0` struct.
   """
-  @spec get(t(), bitboard()) :: non_neg_integer()
+  @spec get(t(), bitboard_type()) :: non_neg_integer()
   def get(bitboard, type) do
     :atomics.get(bitboard.ref, @bitboards[type])
   end

--- a/lib/chess/board/bitboards/pieces/pawn.ex
+++ b/lib/chess/board/bitboards/pieces/pawn.ex
@@ -1,0 +1,23 @@
+defmodule Chess.BitBoards.Pieces.Pawn do
+  @moduledoc """
+  Functions for calculating pawn single and double pushes,
+  attacks, pseudo-legal moves, and legal moves.
+  """
+  use Bitwise
+
+  alias Chess.Boards.BitBoard
+  alias Chess.Color
+
+  @single_push 8
+  @double_push 16
+
+  @spec single_pushes(BitBoard.t(), Color.t()) :: Bitboard.bitboard()
+  def single_pushes(bitboard, color) do
+    bitboard
+    |> BitBoard.get(:"#{color}_pawns")
+    |> operation(color).(@single_push)
+  end
+
+  defp operation(:black), do: &Bitwise.>>>/2
+  defp operation(:white), do: &Bitwise.<<</2
+end

--- a/lib/chess/board/bitboards/pieces/pawn.ex
+++ b/lib/chess/board/bitboards/pieces/pawn.ex
@@ -11,11 +11,18 @@ defmodule Chess.BitBoards.Pieces.Pawn do
   @single_push 8
   @double_push 16
 
-  @spec single_pushes(BitBoard.t(), Color.t()) :: Bitboard.bitboard()
+  @spec single_pushes(BitBoard.t(), Color.t()) :: BitBoard.bitboard()
   def single_pushes(bitboard, color) do
     bitboard
     |> BitBoard.get(:"#{color}_pawns")
     |> operation(color).(@single_push)
+  end
+
+  @spec double_pushes(BitBoard.t(), Color.t()) :: BitBoard.bitboard()
+  def double_pushes(bitboard, color) do
+    bitboard
+    |> BitBoard.get(:"#{color}_pawns")
+    |> operation(color).(@double_push)
   end
 
   defp operation(:black), do: &Bitwise.>>>/2

--- a/lib/chess/board/bitboards/pieces/pawn.ex
+++ b/lib/chess/board/bitboards/pieces/pawn.ex
@@ -14,14 +14,14 @@ defmodule Chess.BitBoards.Pieces.Pawn do
   @spec single_pushes(BitBoard.t(), Color.t()) :: BitBoard.bitboard()
   def single_pushes(bitboard, color) do
     bitboard
-    |> BitBoard.get(:"#{color}_pawns")
+    |> BitBoard.get(String.to_existing_atom("#{color}_pawns"))
     |> operation(color).(@single_push)
   end
 
   @spec double_pushes(BitBoard.t(), Color.t()) :: BitBoard.bitboard()
   def double_pushes(bitboard, color) do
     bitboard
-    |> BitBoard.get(:"#{color}_pawns")
+    |> BitBoard.get(String.to_existing_atom("#{color}_pawns"))
     |> operation(color).(@double_push)
   end
 

--- a/lib/chess/color.ex
+++ b/lib/chess/color.ex
@@ -1,0 +1,11 @@
+defmodule Chess.Color do
+  @moduledoc """
+  Simple module containing types and functions unifying the
+  black and white colors.
+  """
+
+  @type t() :: :white | :black
+
+  def white, do: :white
+  def black, do: :black
+end

--- a/test/chess/board/bitboards/pieces/pawn_test.exs
+++ b/test/chess/board/bitboards/pieces/pawn_test.exs
@@ -3,6 +3,7 @@ defmodule Chess.BitBoards.Pieces.PawnTest do
 
   alias Chess.Boards.BitBoard
   alias Chess.BitBoards.Pieces.Pawn
+  alias Chess.Color
 
   describe "single_pushes/2" do
     test "given an initial state Bitboard.t/0 and white color, pushes all pawns up one rank" do
@@ -30,6 +31,40 @@ defmodule Chess.BitBoards.Pieces.PawnTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [1, 1, 1, 1, 1, 1, 1, 1],
                [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_grid(single_pushes)
+    end
+  end
+
+  describe "double_pushes/2" do
+    test "given an initial state Bitboard.t/0 and white color, pushes all pawns up two ranks" do
+      bitboard = BitBoard.new()
+      double_pushes = Pawn.double_pushes(bitboard, Color.white())
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [1, 1, 1, 1, 1, 1, 1, 1],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_grid(single_pushes)
+    end
+
+    test "given an initial state Bitboard.t/0 and black color, pushes all pawns down two ranks" do
+      bitboard = BitBoard.new()
+      double_pushes = Pawn.double_pushes(bitboard, Color.black())
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [1, 1, 1, 1, 1, 1, 1, 1],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],

--- a/test/chess/board/bitboards/pieces/pawn_test.exs
+++ b/test/chess/board/bitboards/pieces/pawn_test.exs
@@ -1,8 +1,8 @@
 defmodule Chess.BitBoards.Pieces.PawnTest do
   use ExUnit.Case, async: true
 
-  alias Chess.Boards.BitBoard
   alias Chess.BitBoards.Pieces.Pawn
+  alias Chess.Boards.BitBoard
   alias Chess.Color
 
   describe "single_pushes/2" do

--- a/test/chess/board/bitboards/pieces/pawn_test.exs
+++ b/test/chess/board/bitboards/pieces/pawn_test.exs
@@ -53,7 +53,7 @@ defmodule Chess.BitBoards.Pieces.PawnTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(single_pushes)
+             ] == BitBoard.to_grid(double_pushes)
     end
 
     test "given an initial state Bitboard.t/0 and black color, pushes all pawns down two ranks" do
@@ -69,7 +69,7 @@ defmodule Chess.BitBoards.Pieces.PawnTest do
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0],
                [0, 0, 0, 0, 0, 0, 0, 0]
-             ] == BitBoard.to_grid(single_pushes)
+             ] == BitBoard.to_grid(double_pushes)
     end
   end
 end

--- a/test/chess/board/bitboards/pieces/pawn_test.exs
+++ b/test/chess/board/bitboards/pieces/pawn_test.exs
@@ -8,7 +8,7 @@ defmodule Chess.BitBoards.Pieces.PawnTest do
   describe "single_pushes/2" do
     test "given an initial state Bitboard.t/0 and white color, pushes all pawns up one rank" do
       bitboard = BitBoard.new()
-      single_pushes = Pawn.single_pushes(bitboard, :white)
+      single_pushes = Pawn.single_pushes(bitboard, Color.white())
 
       assert [
                [0, 0, 0, 0, 0, 0, 0, 0],
@@ -24,7 +24,7 @@ defmodule Chess.BitBoards.Pieces.PawnTest do
 
     test "given an initial state Bitboard.t/0 and black color, pushes all pawns down one rank" do
       bitboard = BitBoard.new()
-      single_pushes = Pawn.single_pushes(bitboard, :black)
+      single_pushes = Pawn.single_pushes(bitboard, Color.black())
 
       assert [
                [0, 0, 0, 0, 0, 0, 0, 0],

--- a/test/chess/board/bitboards/pieces/pawn_test.exs
+++ b/test/chess/board/bitboards/pieces/pawn_test.exs
@@ -20,5 +20,21 @@ defmodule Chess.BitBoards.Pieces.PawnTest do
                [0, 0, 0, 0, 0, 0, 0, 0]
              ] == BitBoard.to_grid(single_pushes)
     end
+
+    test "given an initial state Bitboard.t/0 and black color, pushes all pawns down one rank" do
+      bitboard = BitBoard.new()
+      single_pushes = Pawn.single_pushes(bitboard, :black)
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [1, 1, 1, 1, 1, 1, 1, 1],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_grid(single_pushes)
+    end
   end
 end

--- a/test/chess/board/bitboards/pieces/pawn_test.exs
+++ b/test/chess/board/bitboards/pieces/pawn_test.exs
@@ -1,0 +1,24 @@
+defmodule Chess.BitBoards.Pieces.PawnTest do
+  use ExUnit.Case, async: true
+
+  alias Chess.Boards.BitBoard
+  alias Chess.BitBoards.Pieces.Pawn
+
+  describe "single_pushes/2" do
+    test "given an initial state Bitboard.t/0 and white color, pushes all pawns up one rank" do
+      bitboard = BitBoard.new()
+      single_pushes = Pawn.single_pushes(bitboard, :white)
+
+      assert [
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [1, 1, 1, 1, 1, 1, 1, 1],
+               [0, 0, 0, 0, 0, 0, 0, 0],
+               [0, 0, 0, 0, 0, 0, 0, 0]
+             ] == BitBoard.to_grid(single_pushes)
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the most basic pawn push functions, with no accounting for out of bounds/overflows or any other state of the board other than the initial state.