### PR TITLE
Binary bitboard representation

### DIFF
--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -88,9 +88,19 @@ defmodule Chess.Boards.BitBoard do
   Returns the specific bitboard denoted by `bitboard_type`
   stored within the `BitBoard.t/0` struct.
   """
-  @spec get(t(), bitboard_type()) :: non_neg_integer()
+  @spec get(t(), bitboard_type()) :: bitboard()
   def get(bitboard, type) do
     Map.fetch!(bitboard, type)
+  end
+
+  @doc """
+  Returns the integer-encoded value of the underlying
+  bitstring for the bitboard.
+  """
+  @spec get_raw(t(), bitboard_type()) :: integer()
+  def get_raw(bitboard, type) do
+    <<value::integer-size(64)>> = get(bitboard, type)
+    value
   end
 
   @doc """

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -104,6 +104,13 @@ defmodule Chess.Boards.BitBoard do
   end
 
   @doc """
+  Takes in an integer value and encodes it as a bitstring
+  representation of a bitboard.
+  """
+  @spec from_integer(integer()) :: bitboard()
+  def from_integer(bitboard), do: <<bitboard::integer-size(64)>>
+
+  @doc """
   Returns an 8x8 grid representation of a given
   bitboard. If the bitboard does not take up a full
   64 bits, the representation is padded with 0s to

--- a/lib/chess/board/bitboards/pieces/pawn.ex
+++ b/lib/chess/board/bitboards/pieces/pawn.ex
@@ -14,15 +14,17 @@ defmodule Chess.BitBoards.Pieces.Pawn do
   @spec single_pushes(BitBoard.t(), Color.t()) :: BitBoard.bitboard()
   def single_pushes(bitboard, color) do
     bitboard
-    |> BitBoard.get(String.to_existing_atom("#{color}_pawns"))
+    |> BitBoard.get_raw(String.to_existing_atom("#{color}_pawns"))
     |> operation(color).(@single_push)
+    |> BitBoard.from_integer()
   end
 
   @spec double_pushes(BitBoard.t(), Color.t()) :: BitBoard.bitboard()
   def double_pushes(bitboard, color) do
     bitboard
-    |> BitBoard.get(String.to_existing_atom("#{color}_pawns"))
+    |> BitBoard.get_raw(String.to_existing_atom("#{color}_pawns"))
     |> operation(color).(@double_push)
+    |> BitBoard.from_integer()
   end
 
   defp operation(:black), do: &Bitwise.>>>/2

--- a/lib/chess/board/bitboards/pieces/pawn.ex
+++ b/lib/chess/board/bitboards/pieces/pawn.ex
@@ -10,6 +10,14 @@ defmodule Chess.BitBoards.Pieces.Pawn do
 
   @single_push 8
   @double_push 16
+  @far_attack 9
+  @near_attack 7
+  @file_a_mask 0b01111111
+  @file_h_mask 0b11111110
+  @full_file_a_mask <<@file_a_mask, @file_a_mask, @file_a_mask, @file_a_mask, @file_a_mask,
+                      @file_a_mask, @file_a_mask, @file_a_mask>>
+  @full_file_h_mask <<@file_h_mask, @file_h_mask, @file_h_mask, @file_h_mask, @file_h_mask,
+                      @file_h_mask, @file_h_mask, @file_h_mask>>
 
   @spec single_pushes(BitBoard.t(), Color.t()) :: BitBoard.bitboard()
   def single_pushes(bitboard, color) do
@@ -25,6 +33,29 @@ defmodule Chess.BitBoards.Pieces.Pawn do
     |> BitBoard.get_raw(String.to_existing_atom("#{color}_pawns"))
     |> operation(color).(@double_push)
     |> BitBoard.from_integer()
+  end
+
+  @spec potential_attacks(BitBoard.t(), Color.t()) :: BitBoard.bitboard()
+  def potential_attacks(bitboard, color) do
+    bitboard = BitBoard.get_raw(bitboard, String.to_existing_atom("#{color}_pawns"))
+
+    <<file_a_mask::integer-size(64)>> = @full_file_a_mask
+    <<file_h_mask::integer-size(64)>> = @full_file_h_mask
+
+    north_west_or_south_west = bitboard &&& file_a_mask
+    north_east_or_south_east = bitboard &&& file_h_mask
+
+    case color do
+      :white ->
+        BitBoard.from_integer(
+          north_west_or_south_west <<< @far_attack ||| north_east_or_south_east <<< @near_attack
+        )
+
+      :black ->
+        BitBoard.from_integer(
+          north_west_or_south_west >>> @near_attack ||| north_east_or_south_east >>> @far_attack
+        )
+    end
   end
 
   defp operation(:black), do: &Bitwise.>>>/2

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -53,6 +53,12 @@ defmodule Chess.Boards.BitBoardTest do
     end
   end
 
+  describe "from_integer/1" do
+    test "returns the bitstring representation of an integer value" do
+      assert <<0, 0, 0, 0, 0, 0, 255, 255>> = BitBoard.from_integer(0b1111111111111111)
+    end
+  end
+
   describe "to_grid/2" do
     test "returns an 8x8 list representation of the composite bitboard" do
       bitboard = BitBoard.new()

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -45,6 +45,14 @@ defmodule Chess.Boards.BitBoardTest do
     end
   end
 
+  describe "get_raw/2" do
+    test "returns the integer-encoded value of the bitboard representation" do
+      bitboard = BitBoard.new()
+
+      assert 0b1111111100000000 = BitBoard.get_raw(bitboard, :white_pawns)
+    end
+  end
+
   describe "to_grid/2" do
     test "returns an 8x8 list representation of the composite bitboard" do
       bitboard = BitBoard.new()

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -4,11 +4,16 @@ defmodule Chess.Boards.BitBoardTest do
   alias Chess.Boards.BitBoard
 
   describe "new/0" do
-    test "creates a BitBoard struct with an atomics ref" do
-      assert %BitBoard{ref: ref} = BitBoard.new()
+    test "creates a BitBoard struct" do
+      assert %BitBoard{} = bitboard = BitBoard.new()
 
-      assert is_reference(ref),
-             "Expected new bitboard to contain a reference, but contained #{inspect(ref)} instead."
+      bitboard
+      |> Map.from_struct()
+      |> Map.values()
+      |> Enum.each(fn board ->
+        assert match?(<<_::integer-size(64)>>, board),
+               "Expected a 64-bit integer wrapped as a bytestring to represent bitboard state. Got: #{inspect(board)}"
+      end)
     end
   end
 
@@ -32,8 +37,10 @@ defmodule Chess.Boards.BitBoardTest do
   describe "get/2" do
     for bitboard_type <- BitBoard.list_types() do
       test "returns bitboard when given #{bitboard_type}" do
-        assert BitBoard.initial_states()[unquote(bitboard_type)] ==
-                 BitBoard.get(BitBoard.new(), unquote(bitboard_type))
+        bitboard = BitBoard.new()
+
+        assert Map.get(bitboard, unquote(bitboard_type)) ==
+                 BitBoard.get(bitboard, unquote(bitboard_type))
       end
     end
   end

--- a/test/chess/board/bitboards/pieces/pawn_test.exs
+++ b/test/chess/board/bitboards/pieces/pawn_test.exs
@@ -72,4 +72,38 @@ defmodule Chess.BitBoards.Pieces.PawnTest do
              ] == BitBoard.to_grid(double_pushes)
     end
   end
+
+  describe "potential_attacks/2" do
+    test "given an initial state bitboard and white's turn, masks the existing pawns on file A and H when presenting attacks" do
+      bitboard = BitBoard.new()
+      potential_attacks = Pawn.potential_attacks(bitboard, Color.white())
+
+      assert assert [
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [1, 1, 1, 1, 1, 1, 1, 1],
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 0, 0]
+                    ] == BitBoard.to_grid(potential_attacks)
+    end
+
+    test "given an initial state bitboard and black's turn, masks the existing pawns on files A and H when presenting attacks" do
+      bitboard = BitBoard.new()
+      potential_attacks = Pawn.potential_attacks(bitboard, Color.black())
+
+      assert assert [
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [1, 1, 1, 1, 1, 1, 1, 1],
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 0, 0]
+                    ] == BitBoard.to_grid(potential_attacks)
+    end
+  end
 end


### PR DESCRIPTION
Changes the representation of bitboards from pure 64-bit integer representations to binary-based representations.