### PR TITLE
Pawn file mask attribute refactor

### DIFF
--- a/lib/chess/board/bitboards/pieces/pawn.ex
+++ b/lib/chess/board/bitboards/pieces/pawn.ex
@@ -33,24 +33,25 @@ defmodule Chess.BitBoards.Pieces.Pawn do
 
   @spec potential_attacks(BitBoard.t(), Color.t()) :: BitBoard.bitboard()
   def potential_attacks(bitboard, color) do
-    bitboard = BitBoard.get_raw(bitboard, String.to_existing_atom("#{color}_pawns"))
-
-    north_west_or_south_west = bitboard &&& @file_a_mask
-    north_east_or_south_east = bitboard &&& @file_h_mask
-
-    case color do
-      :white ->
-        BitBoard.from_integer(
-          north_west_or_south_west <<< @far_attack ||| north_east_or_south_east <<< @near_attack
-        )
-
-      :black ->
-        BitBoard.from_integer(
-          north_west_or_south_west >>> @near_attack ||| north_east_or_south_east >>> @far_attack
-        )
-    end
+    bitboard
+    |> BitBoard.get_raw(String.to_existing_atom("#{color}_pawns"))
+    |> then(fn b -> {b &&& @file_a_mask, b &&& @file_h_mask} end)
+    |> attack_quadrants(color).()
+    |> BitBoard.from_integer()
   end
 
   defp operation(:black), do: &Bitwise.>>>/2
   defp operation(:white), do: &Bitwise.<<</2
+
+  defp attack_quadrants(:white) do
+    fn {north_west, north_east} ->
+      north_west <<< @far_attack ||| north_east <<< @near_attack
+    end
+  end
+
+  defp attack_quadrants(:black) do
+    fn {south_west, south_east} ->
+      south_west >>> @near_attack ||| south_east >>> @far_attack
+    end
+  end
 end

--- a/lib/chess/board/bitboards/pieces/pawn.ex
+++ b/lib/chess/board/bitboards/pieces/pawn.ex
@@ -12,12 +12,8 @@ defmodule Chess.BitBoards.Pieces.Pawn do
   @double_push 16
   @far_attack 9
   @near_attack 7
-  @file_a_mask 0b01111111
-  @file_h_mask 0b11111110
-  @full_file_a_mask <<@file_a_mask, @file_a_mask, @file_a_mask, @file_a_mask, @file_a_mask,
-                      @file_a_mask, @file_a_mask, @file_a_mask>>
-  @full_file_h_mask <<@file_h_mask, @file_h_mask, @file_h_mask, @file_h_mask, @file_h_mask,
-                      @file_h_mask, @file_h_mask, @file_h_mask>>
+  @file_a_mask 0b0111111101111111011111110111111101111111011111110111111101111111
+  @file_h_mask 0b1111111011111110111111101111111011111110111111101111111011111110
 
   @spec single_pushes(BitBoard.t(), Color.t()) :: BitBoard.bitboard()
   def single_pushes(bitboard, color) do
@@ -39,11 +35,8 @@ defmodule Chess.BitBoards.Pieces.Pawn do
   def potential_attacks(bitboard, color) do
     bitboard = BitBoard.get_raw(bitboard, String.to_existing_atom("#{color}_pawns"))
 
-    <<file_a_mask::integer-size(64)>> = @full_file_a_mask
-    <<file_h_mask::integer-size(64)>> = @full_file_h_mask
-
-    north_west_or_south_west = bitboard &&& file_a_mask
-    north_east_or_south_east = bitboard &&& file_h_mask
+    north_west_or_south_west = bitboard &&& @file_a_mask
+    north_east_or_south_east = bitboard &&& @file_h_mask
 
     case color do
       :white ->


### PR DESCRIPTION
This PR makes a small change to the module attributes used for the bitboard Pawn module to declare bit masks for File A and File H when determining potential pawn attacks. 

It also makes a minor, stylistic refactoring on the Pawn.potential_attacks/2 function.