### PR TITLE
feat: Implement en passant move for pawns

### DIFF
--- a/MOVE_GENERATION_REFACTOR_PLAN.md
+++ b/MOVE_GENERATION_REFACTOR_PLAN.md
@@ -1,0 +1,35 @@
+# Move Generation Refactor Plan
+
+This document outlines the steps to refactor the move generation logic to use bitwise operations directly, instead of returning a list of board indices. This will make the move generation more idiomatic for a bitboard-based chess engine and potentially more performant.
+
+## 1. Change `potential_moves` function signature
+
+The `potential_moves` function in the `Piece` behaviour currently returns a `MapSet.t(Board.index())`. This should be changed to return a `BitBoard.bitboard()`, which is a 64-bit integer representing all possible move destinations.
+
+-   Update `lib/chess/pieces/piece.ex` to change the `@callback` for `potential_moves/3`.
+-   Update all modules that implement the `Piece` behaviour (`Pawn`, `Rook`, etc.) to match the new signature.
+
+## 2. Refactor `Pawn.potential_moves`
+
+-   The function will now calculate moves using bitwise shifts on a bitmask of the pawn's position.
+-   Single-step forward move for a white pawn at index `i`: `(1 <<< i) <<< 8`.
+-   Two-step forward move: `(1 <<< i) <<< 16`.
+-   Captures: `(1 <<< i) <<< 7` and `(1 <<< i) <<< 9`.
+-   The function will need to handle edge cases (e.g., wrapping around the board for captures) by masking with a "not-a-file" or "not-h-file" mask.
+-   The final result will be a bitboard created by `|||`-ing the bitboards of all possible moves.
+
+## 3. Refactor other piece move generation
+
+-   Update `Rook`, `Bishop`, `Queen`, `Knight`, and `King` move generation to return a bitboard.
+-   This will involve more complex logic for sliding pieces, likely using pre-calculated attack tables or techniques like "magic bitboards".
+
+## 4. Update move validation and application
+
+-   `Moves.Proposals.validate/2` will need to be updated. Instead of checking if a proposed move index is in a `MapSet`, it will check if the bit for the destination square is set in the potential moves bitboard.
+    -   `potential_moves_bitboard &&& (1 <<< to_index) != 0`
+-   This will require changes in `lib/chess/moves/proposals.ex`.
+
+## 5. Update tests
+
+-   All tests for `potential_moves` functions will need to be updated to work with bitboards instead of `MapSet`s of indices.
+-   This will involve creating expected bitboards for assertions.

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -226,6 +226,7 @@ defmodule Chess.Boards.BitBoard do
 
   defp find_piece_type_at(board, color, coordinates) do
     boards = get_boards_by_color(board, color)
+
     Enum.reduce_while(boards, :error, fn {piece_type, bitboard}, _ ->
       if square_occupied?(bitboard, coordinates) do
         {:halt, {:ok, piece_type}}
@@ -237,14 +238,17 @@ defmodule Chess.Boards.BitBoard do
 
   def remove(board, index, color) do
     coordinates = Coordinates.index_to_coordinates(index)
+
     case find_piece_type_at(board, color, coordinates) do
       {:ok, piece_type} ->
         <<raw_bitboard::integer-size(64)>> = get(board, {color, piece_type})
         mask = 1 <<< (63 - index)
-        new_raw_bitboard = raw_bitboard &&& (bnot(mask))
+        new_raw_bitboard = raw_bitboard &&& bnot(mask)
         new_bitboard = from_integer(new_raw_bitboard)
         put_in(board, [color, piece_type], new_bitboard)
-      _ -> board
+
+      _ ->
+        board
     end
   end
 
@@ -258,12 +262,15 @@ defmodule Chess.Boards.BitBoard do
 
   def update(board, %Move{from: from, to: to}, color) do
     coordinates = Coordinates.index_to_coordinates(from)
+
     case find_piece_type_at(board, color, coordinates) do
       {:ok, piece_type} ->
         board
         |> remove(from, color)
         |> add(to, color, piece_type)
-      _ -> board
+
+      _ ->
+        board
     end
   end
 end

--- a/lib/chess/board/coordinates.ex
+++ b/lib/chess/board/coordinates.ex
@@ -35,4 +35,17 @@ defmodule Chess.Board.Coordinates do
   """
   @spec file_bit_index(file()) :: 0..7
   def file_bit_index(file), do: @bit_indices[file]
+
+  @files ~w(h g f e d c b a)
+
+  @doc """
+  Converts a board index (0-63) to a `{file, rank}` tuple.
+  """
+  @spec index_to_coordinates(0..63) :: t()
+  def index_to_coordinates(index) do
+    rank = 8 - div(index, 8)
+    file_index = rem(index, 8)
+    file = Enum.at(@files, file_index)
+    {file, rank}
+  end
 end

--- a/lib/chess/game.ex
+++ b/lib/chess/game.ex
@@ -48,7 +48,7 @@ defmodule Chess.Game do
 
     # Handle en passant capture
     final_board =
-      if is_en_passant_capture(game, move) do
+      if en_passant_capture?(game, move) do
         captured_pawn_index =
           if game.current_player == :white do
             game.en_passant_target + 8
@@ -72,23 +72,24 @@ defmodule Chess.Game do
     }
   end
 
-  defp is_en_passant_capture(game, %Move{from: from, to: to}) do
-    with {:ok, piece} <- Pieces.classify(game, Coordinates.index_to_coordinates(from)) do
-      piece.type == Chess.Pieces.Pawn && to == game.en_passant_target
-    else
+  defp en_passant_capture?(game, %Move{from: from, to: to}) do
+    case Pieces.classify(game, Coordinates.index_to_coordinates(from)) do
+      {:ok, piece} -> piece.type == Chess.Pieces.Pawn && to == game.en_passant_target
       _ -> false
     end
   end
 
   defp en_passant_target(game, %Move{from: from, to: to}) do
-    with {:ok, piece} <- Pieces.classify(game, from |> Coordinates.index_to_coordinates()) do
-      if piece.type == Chess.Pieces.Pawn && abs(to - from) == 16 do
-        (from + to) |> div(2)
-      else
+    case Pieces.classify(game, from |> Coordinates.index_to_coordinates()) do
+      {:ok, piece} ->
+        if piece.type == Chess.Pieces.Pawn && abs(to - from) == 16 do
+          (from + to) |> div(2)
+        else
+          nil
+        end
+
+      _ ->
         nil
-      end
-    else
-      _ -> nil
     end
   end
 end

--- a/lib/chess/moves/proposals.ex
+++ b/lib/chess/moves/proposals.ex
@@ -64,21 +64,25 @@ defmodule Chess.Moves.Proposals do
   # Just templating this for now as I think through how #
   # to make this interface work nicely.                 #
   #######################################################
-  # @spec validate(Game.t(), t() | inputs()) :: {:valid, Move.t()} | {:invalid, reason}
-  #       when reason: any()
-  # def validate(game, %__MODULE__{} = proposal) do
-  #   with {:ok, piece} <- Pieces.classify(game, proposal.source),
-  #        {:ok, move} <- piece.validate_move(game, proposal) do
-  #     {:valid, move}
-  #   else
-  #     {:error, reason} -> {:invalid, reason}
-  #   end
-  # end
+  alias Chess.Game
+  alias Chess.Move
+  alias Chess.Pieces
 
-  # def validate(game, %{source: _, destination: _} = inputs) do
-  #   case from_inputs(inputs) do
-  #     {:ok, proposal} -> validate(game, proposal)
-  #     {:error, reason} -> {:invalid, reason}
-  #   end
-  # end
+  @spec validate(Game.t(), t() | inputs()) :: {:valid, Move.t()} | {:invalid, reason}
+        when reason: any()
+  def validate(game, %__MODULE__{} = proposal) do
+    with {:ok, piece} <- Pieces.classify(game, proposal.source),
+         {:ok, move} <- piece.type.validate_move(game, proposal) do
+      {:valid, move}
+    else
+      {:error, reason} -> {:invalid, reason}
+    end
+  end
+
+  def validate(game, %{source: _, destination: _} = inputs) do
+    case from_inputs(inputs) do
+      {:ok, proposal} -> validate(game, proposal)
+      {:error, reason} -> {:invalid, reason}
+    end
+  end
 end

--- a/lib/chess/pieces/pawn.ex
+++ b/lib/chess/pieces/pawn.ex
@@ -4,18 +4,41 @@ defmodule Chess.Pieces.Pawn do
   """
   @behaviour Chess.Piece
 
-  alias Chess.Board
-  alias Chess.Board.Square
+alias Chess.Board.Coordinates
+  alias Chess.Boards.BitBoard
   alias Chess.Piece
 
   @impl Piece
-  def potential_moves(%Piece{color: color, moves: moves}, starting_position, board) do
-    moves
-    |> list_of_potential_moves(starting_position, color)
-    |> Stream.filter(&Board.in_bounds?/1)
-    |> Stream.reject(&invalid_capture?(&1, starting_position, color, board))
-    |> Stream.reject(&occupied_non_capture?(&1, starting_position, board))
-    |> MapSet.new()
+  def potential_moves(%Piece{color: color, moves: moves}, starting_position, game) do
+    board = game.board
+
+    regular_moves =
+      moves
+      |> list_of_potential_moves(starting_position, color)
+      |> Stream.filter(&(&1 in 0..63))
+      |> Stream.reject(&invalid_capture?(&1, starting_position, color, board))
+      |> Stream.reject(&occupied_non_capture?(&1, starting_position, board))
+      |> MapSet.new()
+
+    en_passant_move =
+      case game.en_passant_target do
+        nil ->
+          MapSet.new()
+
+        target ->
+          pawn_rank = div(starting_position, 8)
+          en_passant_rank = if color == :white, do: 3, else: 4
+
+          if pawn_rank == en_passant_rank &&
+               (abs(target - (starting_position + 8 * direction_for(color) + 1)) == 0 ||
+                abs(target - (starting_position + 8 * direction_for(color) - 1)) == 0) do
+            MapSet.new([target])
+          else
+            MapSet.new()
+          end
+      end
+
+    MapSet.union(regular_moves, en_passant_move)
   end
 
   @spec list_of_potential_moves(MapSet.t(Board.index()), Board.index(), Piece.color()) ::
@@ -43,7 +66,7 @@ defmodule Chess.Pieces.Pawn do
   defp direction_for(:white), do: -1
   defp direction_for(_), do: 1
 
-  @spec invalid_capture?(Board.index(), Board.index(), Piece.color(), Board.t()) :: boolean()
+  @spec invalid_capture?(Board.index(), Board.index(), Piece.color(), BitBoard.t()) :: boolean()
   defp invalid_capture?(target, starting_point, color, board) do
     case rem(abs(target - starting_point), 8) do
       0 ->
@@ -54,22 +77,19 @@ defmodule Chess.Pieces.Pawn do
     end
   end
 
-  @spec should_drop_diagonal?(Board.index(), Piece.color(), Board.t()) :: boolean()
+  @spec should_drop_diagonal?(Board.index(), Piece.color(), BitBoard.t()) :: boolean()
   defp should_drop_diagonal?(target, color, board) do
-    case board[target] do
-      %Piece{color: target_color} when target_color != color ->
-        false
-
-      _ ->
-        true
-    end
+    opponent_color = if color == :white, do: :black, else: :white
+    opponent_board = BitBoard.get(board, opponent_color)
+    !BitBoard.square_occupied?(opponent_board, Coordinates.index_to_coordinates(target))
   end
 
-  @spec occupied_non_capture?(Board.index(), Board.index(), Board.t()) :: boolean()
+  @spec occupied_non_capture?(Board.index(), Board.index(), BitBoard.t()) :: boolean()
   defp occupied_non_capture?(target, starting_position, board) do
     case rem(abs(target - starting_position), 8) do
       0 ->
-        Square.occupied?(board[target])
+        full_board = BitBoard.get(board, :full)
+        BitBoard.square_occupied?(full_board, Coordinates.index_to_coordinates(target))
 
       _ ->
         false

--- a/lib/chess/pieces/pawn.ex
+++ b/lib/chess/pieces/pawn.ex
@@ -4,7 +4,7 @@ defmodule Chess.Pieces.Pawn do
   """
   @behaviour Chess.Piece
 
-alias Chess.Board.Coordinates
+  alias Chess.Board.Coordinates
   alias Chess.Boards.BitBoard
   alias Chess.Piece
 
@@ -31,7 +31,7 @@ alias Chess.Board.Coordinates
 
           if pawn_rank == en_passant_rank &&
                (abs(target - (starting_position + 8 * direction_for(color) + 1)) == 0 ||
-                abs(target - (starting_position + 8 * direction_for(color) - 1)) == 0) do
+                  abs(target - (starting_position + 8 * direction_for(color) - 1)) == 0) do
             MapSet.new([target])
           else
             MapSet.new()

--- a/lib/chess/pieces/piece.ex
+++ b/lib/chess/pieces/piece.ex
@@ -55,7 +55,8 @@ defmodule Chess.Piece do
   end
 
   @callback potential_moves(t(), Board.index(), Game.t()) :: MapSet.t(Board.index())
-  @callback validate_move(Game.t(), Chess.Moves.Proposals.t()) :: {:ok, Move.t()} | {:error, any()}
+  @callback validate_move(Game.t(), Chess.Moves.Proposals.t()) ::
+              {:ok, Move.t()} | {:error, any()}
 
   @doc """
   Returns a set of squares that a piece could potentially

--- a/lib/chess/pieces/piece.ex
+++ b/lib/chess/pieces/piece.ex
@@ -54,16 +54,17 @@ defmodule Chess.Piece do
     %__MODULE__{piece | moves: MapSet.put(moves, target)}
   end
 
-  @callback potential_moves(t(), Board.index(), Board.t()) :: MapSet.t(Board.index())
+  @callback potential_moves(t(), Board.index(), Game.t()) :: MapSet.t(Board.index())
+  @callback validate_move(Game.t(), Chess.Moves.Proposals.t()) :: {:ok, Move.t()} | {:error, any()}
 
   @doc """
   Returns a set of squares that a piece could potentially
   move to.
   """
-  @spec potential_moves(t(), starting_position :: Board.index(), Board.t()) ::
+  @spec potential_moves(t(), starting_position :: Board.index(), Game.t()) ::
           MapSet.t(Board.index())
-  def potential_moves(%__MODULE__{type: type_module} = piece, starting_position, board) do
-    type_module.potential_moves(piece, starting_position, board)
+  def potential_moves(%__MODULE__{type: type_module} = piece, starting_position, game) do
+    type_module.potential_moves(piece, starting_position, game)
   end
 
   @spec type_at_starting_position(Board.index()) :: type()

--- a/lib/chess/players.ex
+++ b/lib/chess/players.ex
@@ -1,0 +1,15 @@
+defmodule Chess.Players do
+  @moduledoc """
+  This module contains functions for working with players.
+  """
+
+  alias Chess.Color
+
+  @spec alternate(Color.t()) :: Color.t()
+  def alternate(color) do
+    case color do
+      :white -> :black
+      :black -> :white
+    end
+  end
+end

--- a/test/chess/game_test.exs
+++ b/test/chess/game_test.exs
@@ -17,12 +17,27 @@ defmodule Chess.GameTest do
     test "en passant capture removes the captured pawn" do
       # White pawn at c5 (29) captures en passant on d6 (20)
       # The captured black pawn is at d5 (28)
-      white_pawns = BitBoard.from_integer(1 <<< (63-29))
-      black_pawns = BitBoard.from_integer(1 <<< (63-28))
+      white_pawns = BitBoard.from_integer(1 <<< (63 - 29))
+      black_pawns = BitBoard.from_integer(1 <<< (63 - 28))
       empty_board = BitBoard.empty()
+
       board = %BitBoard{
-        white: %{pawns: white_pawns, rooks: empty_board, knights: empty_board, bishops: empty_board, queens: empty_board, king: empty_board},
-        black: %{pawns: black_pawns, rooks: empty_board, knights: empty_board, bishops: empty_board, queens: empty_board, king: empty_board}
+        white: %{
+          pawns: white_pawns,
+          rooks: empty_board,
+          knights: empty_board,
+          bishops: empty_board,
+          queens: empty_board,
+          king: empty_board
+        },
+        black: %{
+          pawns: black_pawns,
+          rooks: empty_board,
+          knights: empty_board,
+          bishops: empty_board,
+          queens: empty_board,
+          king: empty_board
+        }
       }
 
       game = %Game{

--- a/test/chess/game_test.exs
+++ b/test/chess/game_test.exs
@@ -1,5 +1,6 @@
 defmodule Chess.GameTest do
   use ExUnit.Case
+  import Bitwise
 
   alias Chess.Boards.BitBoard
   alias Chess.Color
@@ -9,6 +10,34 @@ defmodule Chess.GameTest do
     test "creates a new chess game instance" do
       assert %Game{board: BitBoard.new(), move_list: [], current_player: Color.white()} ==
                Game.new()
+    end
+  end
+
+  describe "apply_move/2" do
+    test "en passant capture removes the captured pawn" do
+      # White pawn at c5 (29) captures en passant on d6 (20)
+      # The captured black pawn is at d5 (28)
+      white_pawns = BitBoard.from_integer(1 <<< (63-29))
+      black_pawns = BitBoard.from_integer(1 <<< (63-28))
+      empty_board = BitBoard.empty()
+      board = %BitBoard{
+        white: %{pawns: white_pawns, rooks: empty_board, knights: empty_board, bishops: empty_board, queens: empty_board, king: empty_board},
+        black: %{pawns: black_pawns, rooks: empty_board, knights: empty_board, bishops: empty_board, queens: empty_board, king: empty_board}
+      }
+
+      game = %Game{
+        board: board,
+        current_player: :white,
+        en_passant_target: 20
+      }
+
+      move = %Chess.Move{from: 29, to: 20}
+
+      # Bypass validation and call apply_move directly
+      new_game = Game.apply_move(game, move)
+
+      # The black pawn at d5 (28) should be gone.
+      refute BitBoard.square_occupied?(BitBoard.get(new_game.board, :black), {"d", 5})
     end
   end
 end

--- a/test/chess/pieces/pawn_test.exs
+++ b/test/chess/pieces/pawn_test.exs
@@ -2,7 +2,7 @@ defmodule Chess.Pieces.PawnTest do
   use ExUnit.Case
   use ExUnitProperties
 
-  alias Chess.Board
+  alias Chess.Boards.BitBoard
   alias Chess.Piece
   alias Chess.Pieces.Pawn
 
@@ -12,7 +12,7 @@ defmodule Chess.Pieces.PawnTest do
               piece <- piece_generator(),
               starting_position <- integer(0..63)
             ) do
-        game = %Chess.Game{board: Chess.Boards.BitBoard.new()}
+        game = %Chess.Game{board: BitBoard.new()}
         moves = Pawn.potential_moves(piece, starting_position, game)
 
         for move <- moves do
@@ -32,7 +32,7 @@ defmodule Chess.Pieces.PawnTest do
           end
 
         pawn = %Piece{type: Pawn, color: color, moves: MapSet.new()}
-        game = %Chess.Game{board: Chess.Boards.BitBoard.new()}
+        game = %Chess.Game{board: BitBoard.new()}
 
         assert MapSet.new([
                  unquote(starting_index) + 8 * orientation,
@@ -51,7 +51,7 @@ defmodule Chess.Pieces.PawnTest do
             _ -> piece
           end
 
-        game = %Chess.Game{board: Chess.Boards.BitBoard.new()}
+        game = %Chess.Game{board: BitBoard.new()}
         potential_moves = Pawn.potential_moves(piece, starting_position, game)
         assert Enum.count(potential_moves) <= 3
 
@@ -81,12 +81,13 @@ defmodule Chess.Pieces.PawnTest do
       # Black pawn at d7 (11) moves to d5 (27), en passant target is d6 (19)
       # White pawn at c5 (26) should be able to capture en passant at d6 (19)
       game = %Chess.Game{
-        board: Chess.Boards.BitBoard.new(),
+        board: BitBoard.new(),
         current_player: :white,
         en_passant_target: 19
       }
 
-      pawn = %Piece{type: Pawn, color: :white, moves: MapSet.new([42])} # Moved from c2
+      # Moved from c2
+      pawn = %Piece{type: Pawn, color: :white, moves: MapSet.new([42])}
       moves = Pawn.potential_moves(pawn, 26, game)
       assert MapSet.member?(moves, 19)
     end
@@ -95,12 +96,13 @@ defmodule Chess.Pieces.PawnTest do
       # White pawn at e2 (52) moves to e4 (36), en passant target is e3 (44)
       # Black pawn at d4 (35) should be able to capture en passant at e3 (44)
       game = %Chess.Game{
-        board: Chess.Boards.BitBoard.new(),
+        board: BitBoard.new(),
         current_player: :black,
         en_passant_target: 44
       }
 
-      pawn = %Piece{type: Pawn, color: :black, moves: MapSet.new([11])} # Moved from d7
+      # Moved from d7
+      pawn = %Piece{type: Pawn, color: :black, moves: MapSet.new([11])}
       moves = Pawn.potential_moves(pawn, 35, game)
       assert MapSet.member?(moves, 44)
     end
@@ -108,7 +110,7 @@ defmodule Chess.Pieces.PawnTest do
     test "does not allow en passant if target is not set" do
       # Same setup as "allows en passant capture for white pawn", but en_passant_target is nil
       game = %Chess.Game{
-        board: Chess.Boards.BitBoard.new(),
+        board: BitBoard.new(),
         current_player: :white,
         en_passant_target: nil
       }
@@ -121,9 +123,10 @@ defmodule Chess.Pieces.PawnTest do
     test "does not allow en passant if pawn is on wrong rank" do
       # White pawn at c4 (34), not on rank 5, so cannot capture en passant
       game = %Chess.Game{
-        board: Chess.Boards.BitBoard.new(),
+        board: BitBoard.new(),
         current_player: :white,
-        en_passant_target: 19 # en passant target is d6
+        # en passant target is d6
+        en_passant_target: 19
       }
 
       pawn = %Piece{type: Pawn, color: :white, moves: MapSet.new([42])}

--- a/test/chess/pieces/pawn_test.exs
+++ b/test/chess/pieces/pawn_test.exs
@@ -12,7 +12,8 @@ defmodule Chess.Pieces.PawnTest do
               piece <- piece_generator(),
               starting_position <- integer(0..63)
             ) do
-        moves = Pawn.potential_moves(piece, starting_position, Board.layout())
+        game = %Chess.Game{board: Chess.Boards.BitBoard.new()}
+        moves = Pawn.potential_moves(piece, starting_position, game)
 
         for move <- moves do
           assert move >= 0 && move <= 64
@@ -31,11 +32,12 @@ defmodule Chess.Pieces.PawnTest do
           end
 
         pawn = %Piece{type: Pawn, color: color, moves: MapSet.new()}
+        game = %Chess.Game{board: Chess.Boards.BitBoard.new()}
 
         assert MapSet.new([
                  unquote(starting_index) + 8 * orientation,
                  unquote(starting_index) + 16 * orientation
-               ]) == Pawn.potential_moves(pawn, unquote(starting_index), Board.layout())
+               ]) == Pawn.potential_moves(pawn, unquote(starting_index), game)
       end
     end
   end
@@ -49,7 +51,8 @@ defmodule Chess.Pieces.PawnTest do
             _ -> piece
           end
 
-        potential_moves = Pawn.potential_moves(piece, starting_position, Board.layout())
+        game = %Chess.Game{board: Chess.Boards.BitBoard.new()}
+        potential_moves = Pawn.potential_moves(piece, starting_position, game)
         assert Enum.count(potential_moves) <= 3
 
         {straight_moves, diagonal_captures} =
@@ -70,6 +73,62 @@ defmodule Chess.Pieces.PawnTest do
           moves <- StreamData.list_of(integer(0..63))
         ) do
       %Piece{type: type, color: color, moves: moves}
+    end
+  end
+
+  describe "potential_moves/3 with en passant" do
+    test "allows en passant capture for white pawn" do
+      # Black pawn at d7 (11) moves to d5 (27), en passant target is d6 (19)
+      # White pawn at c5 (26) should be able to capture en passant at d6 (19)
+      game = %Chess.Game{
+        board: Chess.Boards.BitBoard.new(),
+        current_player: :white,
+        en_passant_target: 19
+      }
+
+      pawn = %Piece{type: Pawn, color: :white, moves: MapSet.new([42])} # Moved from c2
+      moves = Pawn.potential_moves(pawn, 26, game)
+      assert MapSet.member?(moves, 19)
+    end
+
+    test "allows en passant capture for black pawn" do
+      # White pawn at e2 (52) moves to e4 (36), en passant target is e3 (44)
+      # Black pawn at d4 (35) should be able to capture en passant at e3 (44)
+      game = %Chess.Game{
+        board: Chess.Boards.BitBoard.new(),
+        current_player: :black,
+        en_passant_target: 44
+      }
+
+      pawn = %Piece{type: Pawn, color: :black, moves: MapSet.new([11])} # Moved from d7
+      moves = Pawn.potential_moves(pawn, 35, game)
+      assert MapSet.member?(moves, 44)
+    end
+
+    test "does not allow en passant if target is not set" do
+      # Same setup as "allows en passant capture for white pawn", but en_passant_target is nil
+      game = %Chess.Game{
+        board: Chess.Boards.BitBoard.new(),
+        current_player: :white,
+        en_passant_target: nil
+      }
+
+      pawn = %Piece{type: Pawn, color: :white, moves: MapSet.new([42])}
+      moves = Pawn.potential_moves(pawn, 26, game)
+      refute MapSet.member?(moves, 19)
+    end
+
+    test "does not allow en passant if pawn is on wrong rank" do
+      # White pawn at c4 (34), not on rank 5, so cannot capture en passant
+      game = %Chess.Game{
+        board: Chess.Boards.BitBoard.new(),
+        current_player: :white,
+        en_passant_target: 19 # en passant target is d6
+      }
+
+      pawn = %Piece{type: Pawn, color: :white, moves: MapSet.new([42])}
+      moves = Pawn.potential_moves(pawn, 34, game)
+      refute MapSet.member?(moves, 19)
     end
   end
 end

--- a/test/chess/pieces_test.exs
+++ b/test/chess/pieces_test.exs
@@ -29,47 +29,50 @@ defmodule Chess.PiecesTest do
                                 |> Map.merge(@rank_7_mappings)
                                 |> Map.merge(@rank_8_mappings)
 
+  alias Chess.Boards.BitBoard
+
   describe "classify/1" do
-    for white_rank <- [1, 2], file <- ?a..?h do
-      test "returns an ok tuple with the correct piece type for white starting coordinates at #{<<file>>}#{white_rank}" do
-        game = Game.new()
-        source_coordinate = {<<unquote(file)>>, unquote(white_rank)}
+    for white_rank <- [1, 2], file <- Enum.map(?a..?h, &<<&1>>) do
+      test "returns an ok tuple with the correct piece type for white starting coordinates at #{file}#{white_rank}" do
+        game = %{Game.new() | board: BitBoard.new()}
+        source_coordinate = {unquote(file), unquote(white_rank)}
 
         assert {:ok, piece} = Pieces.classify(game, source_coordinate)
 
-        assert piece == @coordinate_to_piece_mappings[{<<unquote(file)>>, unquote(white_rank)}]
+        assert piece == @coordinate_to_piece_mappings[{unquote(file), unquote(white_rank)}]
       end
     end
 
-    for black_rank <- [7, 8], file <- ?a..?h do
-      test "returns an ok tuple with the correct piece type for black starting coordinates at #{<<file>>}#{black_rank}" do
-        game = Game.new()
-        game = %Game{game | current_player: Chess.Color.black()}
-        source_coordinate = {<<unquote(file)>>, unquote(black_rank)}
+    for black_rank <- [7, 8], file <- Enum.map(?a..?h, &<<&1>>) do
+      test "returns an ok tuple with the correct piece type for black starting coordinates at #{file}#{black_rank}" do
+        game = %{Game.new() | board: BitBoard.new(), current_player: Chess.Color.black()}
+        source_coordinate = {unquote(file), unquote(black_rank)}
 
         assert {:ok, piece} = Pieces.classify(game, source_coordinate)
 
-        assert piece == @coordinate_to_piece_mappings[{<<unquote(file)>>, unquote(black_rank)}]
+        assert piece == @coordinate_to_piece_mappings[{unquote(file), unquote(black_rank)}]
       end
     end
 
     test "returns {:error, :unoccupied} for squares occupied by the player of the other color" do
-      assert {:error, :unoccupied} = Pieces.classify(Game.new(), {"a", 8})
+      game = %{Game.new() | board: BitBoard.new()}
+      assert {:error, :unoccupied} = Pieces.classify(game, {"a", 8})
     end
 
     property "returns {:error, :unoccupied} for blank squares" do
       check all(unoccupied_coordinates <- unoccupied_coordinate_generator()) do
-        assert {:error, :unoccupied} = Pieces.classify(Game.new(), unoccupied_coordinates)
+        game = %{Game.new() | board: BitBoard.new()}
+        assert {:error, :unoccupied} = Pieces.classify(game, unoccupied_coordinates)
       end
     end
   end
 
   def unoccupied_coordinate_generator do
     gen all(
-          file <- StreamData.string(?a..?h, min_length: 1, max_length: 1),
+          file <- StreamData.member_of(?a..?h),
           rank <- StreamData.integer(3..6)
         ) do
-      {file, rank}
+      {<<file>>, rank}
     end
   end
 end


### PR DESCRIPTION
This change implements the 'en passant' special move for pawns.

The `Game` struct is updated to include an `en_passant_target` field, which records the square that is available for an en passant capture. This target is set when a pawn makes a two-square advance.

The `Pawn.potential_moves/3` function is updated to include en passant captures as a possible move, checking the `en_passant_target` and the pawn's rank.

The `Game.apply_move/2` function is updated to handle the capture of the pawn in an en passant move, removing the captured pawn from the board.

The implementation is based on a bitboard representation of the board state. New functions `BitBoard.add/4`, `BitBoard.remove/3`, and `BitBoard.update/3` are added to manipulate the bitboards.

Tests have been added to verify the en passant logic, including the removal of the captured pawn.

A plan for a future refactoring of the move generation logic to use bitwise operations more extensively has been created in `MOVE_GENERATION_REFACTOR_PLAN.md`.