### PR TITLE
King move validation, part 2: king safety

### DIFF
--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -8,16 +8,42 @@ defmodule Chess.BitBoards.Pieces.King do
   import Bitwise
 
   alias Chess.Bitboards.Move
+  alias Chess.Bitboards.Slider
   alias Chess.Boards.BitBoard
   alias Chess.Boards.Bitboards.Square
   alias Chess.Game
   alias Chess.Moves.Proposals
 
+  @knight_deltas [
+    {1, 2},
+    {2, 1},
+    {-1, 2},
+    {-2, 1},
+    {1, -2},
+    {2, -1},
+    {-1, -2},
+    {-2, -1}
+  ]
+
+  @king_deltas [
+    {-1, -1},
+    {-1, 0},
+    {-1, 1},
+    {0, -1},
+    {0, 1},
+    {1, -1},
+    {1, 0},
+    {1, 1}
+  ]
+
+  @piece_types [:pawns, :rooks, :knights, :bishops, :queens, :king]
+
   @impl Chess.Moves.Validator
   @spec validate_move(Game.t(), Proposals.t()) :: {:ok, Move.t()} | {:error, atom()}
   def validate_move(game, %Proposals{source: source, destination: destination}) do
     with :ok <- validate_geometry(source, destination),
-         :ok <- validate_not_self_capture(game, destination) do
+         :ok <- validate_not_self_capture(game, destination),
+         :ok <- validate_king_safety(game, source, destination) do
       {:ok, %Move{from: source, to: destination, flag: move_flag(game, destination)}}
     end
   end
@@ -27,8 +53,11 @@ defmodule Chess.BitBoards.Pieces.King do
   in the given board position.
   """
   @spec in_check?(BitBoard.t(), Chess.player()) :: boolean()
-  def in_check?(_board, _color) do
-    false
+  def in_check?(board, color) do
+    case king_square(board, color) do
+      nil -> false
+      square -> attacked_by?(board, opponent(color), square)
+    end
   end
 
   defp validate_geometry(source, destination) do
@@ -47,6 +76,16 @@ defmodule Chess.BitBoards.Pieces.King do
     end
   end
 
+  defp validate_king_safety(game, source, destination) do
+    board_after_move = apply_king_move(game.board, game.current_player, source, destination)
+
+    if in_check?(board_after_move, game.current_player) do
+      {:error, :king_in_check}
+    else
+      :ok
+    end
+  end
+
   defp move_flag(game, destination) do
     opponent = opponent(game.current_player)
 
@@ -55,6 +94,135 @@ defmodule Chess.BitBoards.Pieces.King do
     else
       :quiet
     end
+  end
+
+  defp apply_king_move(board, color, from, to) do
+    from_mask = Square.bitboard(from)
+    to_mask = Square.bitboard(to)
+    opponent = opponent(color)
+
+    board
+    |> clear_square(opponent, to_mask)
+    |> move_piece(color, :king, from_mask, to_mask)
+  end
+
+  defp clear_square(board, color, square_mask) do
+    Enum.reduce(@piece_types, board, fn piece_type, acc ->
+      <<pieces::integer-size(64)>> = acc[{color, piece_type}]
+      put_in(acc[{color, piece_type}], BitBoard.from_integer(pieces &&& bnot(square_mask)))
+    end)
+  end
+
+  defp move_piece(board, color, piece_type, from_mask, to_mask) do
+    <<pieces::integer-size(64)>> = board[{color, piece_type}]
+    updated = (pieces &&& bnot(from_mask)) ||| to_mask
+    put_in(board[{color, piece_type}], BitBoard.from_integer(updated))
+  end
+
+  defp king_square(board, color) do
+    case BitBoard.get_raw(board, {color, :king}) do
+      0 -> nil
+      king_bits -> bit_to_square(king_bits)
+    end
+  end
+
+  defp bit_to_square(bits) do
+    bit_index = trailing_zeros(bits)
+    rank = div(bit_index, 8) + 1
+    file = Enum.at(~w(h g f e d c b a), rem(bit_index, 8))
+    {file, rank}
+  end
+
+  defp trailing_zeros(n), do: trailing_zeros(n, 0)
+  defp trailing_zeros(n, index) when (n &&& 1) == 1, do: index
+  defp trailing_zeros(n, index), do: trailing_zeros(n >>> 1, index + 1)
+
+  defp attacked_by?(board, attacker, square) do
+    attacked_by_king?(board, attacker, square) or
+      attacked_by_knight?(board, attacker, square) or
+      attacked_by_pawn?(board, attacker, square) or
+      attacked_by_slider?(board, attacker, square)
+  end
+
+  defp attacked_by_king?(board, attacker, square) do
+    Enum.any?(@king_deltas, fn delta ->
+      case offset_square(square, delta) do
+        {:ok, origin} -> occupied_by_piece?(board, attacker, :king, origin)
+        :error -> false
+      end
+    end)
+  end
+
+  defp attacked_by_knight?(board, attacker, square) do
+    Enum.any?(@knight_deltas, fn delta ->
+      case offset_square(square, delta) do
+        {:ok, origin} -> occupied_by_piece?(board, attacker, :knights, origin)
+        :error -> false
+      end
+    end)
+  end
+
+  defp attacked_by_pawn?(board, attacker, square) do
+    pawn_origins(attacker, square)
+    |> Enum.any?(fn origin -> occupied_by_piece?(board, attacker, :pawns, origin) end)
+  end
+
+  defp pawn_origins(:white, square) do
+    # White pawns attack one rank forward diagonally, so they sit one rank below.
+    for file_delta <- [-1, 1],
+        {:ok, origin} <- [offset_square(square, {file_delta, -1})],
+        do: origin
+  end
+
+  defp pawn_origins(:black, square) do
+    for file_delta <- [-1, 1],
+        {:ok, origin} <- [offset_square(square, {file_delta, 1})],
+        do: origin
+  end
+
+  defp attacked_by_slider?(board, attacker, square) do
+    occupied = BitBoard.get_raw(board, :full)
+
+    Enum.any?(Slider.rook().deltas ++ Slider.bishop().deltas, fn delta ->
+      case first_occupied_along(square, delta, occupied) do
+        nil ->
+          false
+
+        blocker ->
+          sliding_attacker?(board, attacker, blocker, delta)
+      end
+    end)
+  end
+
+  defp first_occupied_along(square, delta, occupied) do
+    case offset_square(square, delta) do
+      :error ->
+        nil
+
+      {:ok, next} ->
+        if (Square.bitboard(next) &&& occupied) != 0 do
+          next
+        else
+          first_occupied_along(next, delta, occupied)
+        end
+    end
+  end
+
+  defp sliding_attacker?(board, attacker, blocker, {file_delta, rank_delta}) do
+    orthogonal? = file_delta == 0 or rank_delta == 0
+
+    if orthogonal? do
+      occupied_by_piece?(board, attacker, :rooks, blocker) or
+        occupied_by_piece?(board, attacker, :queens, blocker)
+    else
+      occupied_by_piece?(board, attacker, :bishops, blocker) or
+        occupied_by_piece?(board, attacker, :queens, blocker)
+    end
+  end
+
+  defp occupied_by_piece?(board, color, piece_type, square) do
+    pieces = BitBoard.get_raw(board, {color, piece_type})
+    (pieces &&& Square.bitboard(square)) != 0
   end
 
   defp occupied_by?(board, color, square) do
@@ -70,5 +238,15 @@ defmodule Chess.BitBoards.Pieces.King do
     rank_delta = abs(to_rank - from_rank)
 
     file_delta <= 1 and rank_delta <= 1 and {file_delta, rank_delta} != {0, 0}
+  end
+
+  defp offset_square({<<file>>, rank}, {file_delta, rank_delta}) do
+    case {<<file + file_delta>>, rank + rank_delta} do
+      {<<new_file>>, new_rank} when new_file in ?a..?h and new_rank in 1..8 ->
+        {:ok, {<<new_file>>, new_rank}}
+
+      _ ->
+        :error
+    end
   end
 end

--- a/test/chess/board/bitboards/pieces/king_test.exs
+++ b/test/chess/board/bitboards/pieces/king_test.exs
@@ -167,6 +167,140 @@ defmodule Chess.BitBoards.Pieces.KingTest do
 
       assert {:error, :invalid_geometry} = King.validate_move(game, proposal)
     end
+
+    test "rejects a move onto a square attacked by an opponent rook" do
+      # Board state: White king on e1, black rook on f8.
+      # Move: e1 -> f1 (f-file is attacked by rook)
+      # Expected: {:error, :king_in_check}
+      #
+      #     a   b   c   d   e   f   g   h
+      #   +---+---+---+---+---+---+---+---+
+      # 8 |   |   |   |   |   | r |   |   |  <- black rook controls f-file
+      #   +---+---+---+---+---+---+---+---+
+      # 7 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 6 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 5 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 4 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 3 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 2 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 1 |   |   |   |   | K | X |   |   |  <- f1 attacked, can't go there
+      #   +---+---+---+---+---+---+---+---+
+      game =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:black, :rooks}, {"f", 8}}
+        ])
+        |> then(&%Game{board: &1})
+
+      proposal = %Proposals{source: {"e", 1}, destination: {"f", 1}}
+
+      assert {:error, :king_in_check} = King.validate_move(game, proposal)
+    end
+
+    test "accepts a corner move to an adjacent diagonal square" do
+      # Board state: White king on a1.
+      # Move: a1 -> b2 (only 3 valid moves from a1: a2, b1, b2)
+      # Expected: {:ok, %Move{from: {"a", 1}, to: {"b", 2}, flag: :quiet}}
+      #
+      #     a   b   c   d   e   f   g   h
+      #   +---+---+---+---+---+---+---+---+
+      # 8 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 7 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 6 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 5 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 4 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 3 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 2 |   | * |   |   |   |   |   |   |  <- destination
+      #   +---+---+---+---+---+---+---+---+
+      # 1 | K |   |   |   |   |   |   |   |  <- white king in corner
+      #   +---+---+---+---+---+---+---+---+
+      game = game_with_white_king_on({"a", 1})
+      proposal = %Proposals{source: {"a", 1}, destination: {"b", 2}}
+
+      assert {:ok, %Move{from: {"a", 1}, to: {"b", 2}, flag: :quiet}} =
+               King.validate_move(game, proposal)
+    end
+  end
+
+  describe "in_check?/2" do
+    test "returns false when the king is not under attack" do
+      board = board_with([{{:white, :king}, {"e", 1}}])
+
+      refute King.in_check?(board, :white)
+    end
+
+    test "returns true when an opponent rook attacks the king" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:black, :rooks}, {"e", 8}}
+        ])
+
+      assert King.in_check?(board, :white)
+    end
+
+    test "returns false when a friendly piece blocks an opponent rook" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:white, :pawns}, {"e", 2}},
+          {{:black, :rooks}, {"e", 8}}
+        ])
+
+      refute King.in_check?(board, :white)
+    end
+
+    test "returns true when an opponent bishop attacks the king diagonally" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:black, :bishops}, {"b", 4}}
+        ])
+
+      assert King.in_check?(board, :white)
+    end
+
+    test "returns true when an opponent knight attacks the king" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 4}},
+          {{:black, :knights}, {"d", 6}}
+        ])
+
+      assert King.in_check?(board, :white)
+    end
+
+    test "returns true when an opponent pawn attacks the king" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 4}},
+          {{:black, :pawns}, {"d", 5}}
+        ])
+
+      assert King.in_check?(board, :white)
+    end
+
+    test "returns true when an opponent king is adjacent" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 4}},
+          {{:black, :king}, {"e", 5}}
+        ])
+
+      assert King.in_check?(board, :white)
+    end
   end
 
   defp game_with_white_king_on(square) do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part 1 covered king geometry, self-capture, and quiet/capture flags. This continues the king plan with the shared king-safety infrastructure.

## Changes
- Implement `King.in_check?/2` by detecting attacks from opponent king, knight, pawn, and sliding pieces (rook/bishop/queen)
- Simulate the proposed king move on the bitboard, then reject moves that leave the king in check (`:king_in_check`)
- Add plan Test 6 (cannot move onto a square attacked by a rook) and Test 11 (corner diagonal move)
- Add focused `in_check?/2` coverage for rook, bishop, knight, pawn, and adjacent-king attacks, plus a blocked-ray case

## Still remaining for King
Castling (plan tests 7–10): kingside/queenside success and rejection when the king has moved or would pass through check.

## Test plan
- [x] `mix credo --strict`
- [x] `mix format --check-formatted`
- [x] `mix test` (191 tests, 5 properties, 0 failures)
- [x] `mix test test/chess/board/bitboards/pieces/king_test.exs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7c2b-41d4-73b3-b97b-86426237bdcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7c2b-41d4-73b3-b97b-86426237bdcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

