### PR TITLE
Extract Chess.Bitboards.Attacks with bitwise reverse attacks

### DIFF
--- a/lib/chess/board/bitboards/attacks.ex
+++ b/lib/chess/board/bitboards/attacks.ex
@@ -1,0 +1,145 @@
+defmodule Chess.Bitboards.Attacks do
+  @moduledoc """
+  Bitwise attack detection for chess bitboards.
+
+  Given a target square, generates reverse-attack sets via shifts and file
+  masks (and occupancy-aware slider rays), then intersects those sets with
+  opponent piece bitboards. Prefer this over coordinate/`Enum` iteration for
+  engine hot paths such as king-safety checks.
+
+  Bitboard layout matches the rest of the engine: bit 0 is h1, bit 7 is a1,
+  bit 8 is h2, …, bit 63 is a8. Shifts toward the a-file increase the bit
+  index; shifts toward the h-file decrease it.
+  """
+
+  import Bitwise
+
+  alias Chess.Boards.BitBoard
+  alias Chess.Boards.Bitboards.Square
+
+  # Same masks as `Chess.BitBoards.Pieces.Pawn` — clear a/h files so shifts
+  # cannot wrap across the board edge.
+  @file_a_mask 0b0111111101111111011111110111111101111111011111110111111101111111
+  @file_h_mask 0b1111111011111110111111101111111011111110111111101111111011111110
+  @file_ab_mask 0b0011111100111111001111110011111100111111001111110011111100111111
+  @file_gh_mask 0b1111110011111100111111001111110011111100111111001111110011111100
+
+  @not_rank_1 0b1111111111111111111111111111111111111111111111111111111100000000
+  @not_rank_8 0b0000000011111111111111111111111111111111111111111111111111111111
+  @not_rank_12 0b1111111111111111111111111111111111111111111111110000000000000000
+  @not_rank_78 0b0000000000000000111111111111111111111111111111111111111111111111
+
+  @doc """
+  Returns true if any piece of `attacker` color attacks `square`.
+  """
+  @spec square_attacked_by?(BitBoard.t(), Chess.player(), Square.t()) :: boolean()
+  def square_attacked_by?(board, attacker, square) do
+    target = Square.bitboard(square)
+    occupied = BitBoard.get_raw(board, :full)
+
+    attacked_by_king?(board, attacker, target) or
+      attacked_by_knight?(board, attacker, target) or
+      attacked_by_pawn?(board, attacker, target) or
+      attacked_by_slider?(board, attacker, target, occupied)
+  end
+
+  defp attacked_by_king?(board, attacker, target) do
+    (king_attacks(target) &&& BitBoard.get_raw(board, {attacker, :king})) != 0
+  end
+
+  defp attacked_by_knight?(board, attacker, target) do
+    (knight_attacks(target) &&& BitBoard.get_raw(board, {attacker, :knights})) != 0
+  end
+
+  defp attacked_by_pawn?(board, attacker, target) do
+    (pawn_attackers(attacker, target) &&& BitBoard.get_raw(board, {attacker, :pawns})) != 0
+  end
+
+  defp attacked_by_slider?(board, attacker, target, occupied) do
+    ortho =
+      BitBoard.get_raw(board, {attacker, :rooks}) ||| BitBoard.get_raw(board, {attacker, :queens})
+
+    diag =
+      BitBoard.get_raw(board, {attacker, :bishops}) |||
+        BitBoard.get_raw(board, {attacker, :queens})
+
+    (rook_attacks(target, occupied) &&& ortho) != 0 or
+      (bishop_attacks(target, occupied) &&& diag) != 0
+  end
+
+  # King attacks from a single-bit square (identical to reverse king attackers).
+  defp king_attacks(bit) do
+    # NW (toward a, up), N, NE (toward h, up), W, E, SW, S, SE
+    ((bit &&& @file_a_mask &&& @not_rank_8) <<< 9) |||
+      ((bit &&& @not_rank_8) <<< 8) |||
+      ((bit &&& @file_h_mask &&& @not_rank_8) <<< 7) |||
+      ((bit &&& @file_a_mask) <<< 1) |||
+      ((bit &&& @file_h_mask) >>> 1) |||
+      ((bit &&& @file_a_mask &&& @not_rank_1) >>> 7) |||
+      ((bit &&& @not_rank_1) >>> 8) |||
+      ((bit &&& @file_h_mask &&& @not_rank_1) >>> 9)
+  end
+
+  defp knight_attacks(bit) do
+    ((bit &&& @file_a_mask &&& @not_rank_78) <<< 17) |||
+      ((bit &&& @file_h_mask &&& @not_rank_78) <<< 15) |||
+      ((bit &&& @file_ab_mask &&& @not_rank_8) <<< 10) |||
+      ((bit &&& @file_gh_mask &&& @not_rank_8) <<< 6) |||
+      ((bit &&& @file_ab_mask &&& @not_rank_1) >>> 6) |||
+      ((bit &&& @file_gh_mask &&& @not_rank_1) >>> 10) |||
+      ((bit &&& @file_a_mask &&& @not_rank_12) >>> 15) |||
+      ((bit &&& @file_h_mask &&& @not_rank_12) >>> 17)
+  end
+
+  # Squares from which a pawn of `attacker` color attacks `target`.
+  # White pawns attack via <<<7 / <<<9; black via >>>7 / >>>9 (see Pawn).
+  defp pawn_attackers(:white, target) do
+    ((target &&& @file_a_mask) >>> 7) ||| ((target &&& @file_h_mask) >>> 9)
+  end
+
+  defp pawn_attackers(:black, target) do
+    ((target &&& @file_a_mask) <<< 9) ||| ((target &&& @file_h_mask) <<< 7)
+  end
+
+  defp rook_attacks(bit, occupied) do
+    ray_attacks(bit, occupied, &north/1) |||
+      ray_attacks(bit, occupied, &south/1) |||
+      ray_attacks(bit, occupied, &toward_a/1) |||
+      ray_attacks(bit, occupied, &toward_h/1)
+  end
+
+  defp bishop_attacks(bit, occupied) do
+    ray_attacks(bit, occupied, &northwest/1) |||
+      ray_attacks(bit, occupied, &northeast/1) |||
+      ray_attacks(bit, occupied, &southwest/1) |||
+      ray_attacks(bit, occupied, &southeast/1)
+  end
+
+  # Walk occupancy in one direction: include empty squares along the ray and
+  # the first occupied square (the blocker), then stop.
+  defp ray_attacks(bit, occupied, step) do
+    do_ray_attacks(step.(bit), occupied, step, 0)
+  end
+
+  defp do_ray_attacks(0, _occupied, _step, acc), do: acc
+
+  defp do_ray_attacks(bit, occupied, step, acc) do
+    acc = acc ||| bit
+
+    if (bit &&& occupied) != 0 do
+      acc
+    else
+      do_ray_attacks(step.(bit), occupied, step, acc)
+    end
+  end
+
+  defp north(bit), do: (bit &&& @not_rank_8) <<< 8
+  defp south(bit), do: (bit &&& @not_rank_1) >>> 8
+  defp toward_a(bit), do: (bit &&& @file_a_mask) <<< 1
+  defp toward_h(bit), do: (bit &&& @file_h_mask) >>> 1
+
+  defp northwest(bit), do: (bit &&& @file_a_mask &&& @not_rank_8) <<< 9
+  defp northeast(bit), do: (bit &&& @file_h_mask &&& @not_rank_8) <<< 7
+  defp southwest(bit), do: (bit &&& @file_a_mask &&& @not_rank_1) >>> 7
+  defp southeast(bit), do: (bit &&& @file_h_mask &&& @not_rank_1) >>> 9
+end

--- a/lib/chess/board/bitboards/attacks.ex
+++ b/lib/chess/board/bitboards/attacks.ex
@@ -70,35 +70,35 @@ defmodule Chess.Bitboards.Attacks do
   # King attacks from a single-bit square (identical to reverse king attackers).
   defp king_attacks(bit) do
     # NW (toward a, up), N, NE (toward h, up), W, E, SW, S, SE
-    ((bit &&& @file_a_mask &&& @not_rank_8) <<< 9) |||
-      ((bit &&& @not_rank_8) <<< 8) |||
-      ((bit &&& @file_h_mask &&& @not_rank_8) <<< 7) |||
-      ((bit &&& @file_a_mask) <<< 1) |||
-      ((bit &&& @file_h_mask) >>> 1) |||
-      ((bit &&& @file_a_mask &&& @not_rank_1) >>> 7) |||
-      ((bit &&& @not_rank_1) >>> 8) |||
-      ((bit &&& @file_h_mask &&& @not_rank_1) >>> 9)
+    (bit &&& @file_a_mask &&& @not_rank_8) <<< 9 |||
+      (bit &&& @not_rank_8) <<< 8 |||
+      (bit &&& @file_h_mask &&& @not_rank_8) <<< 7 |||
+      (bit &&& @file_a_mask) <<< 1 |||
+      (bit &&& @file_h_mask) >>> 1 |||
+      (bit &&& @file_a_mask &&& @not_rank_1) >>> 7 |||
+      (bit &&& @not_rank_1) >>> 8 |||
+      (bit &&& @file_h_mask &&& @not_rank_1) >>> 9
   end
 
   defp knight_attacks(bit) do
-    ((bit &&& @file_a_mask &&& @not_rank_78) <<< 17) |||
-      ((bit &&& @file_h_mask &&& @not_rank_78) <<< 15) |||
-      ((bit &&& @file_ab_mask &&& @not_rank_8) <<< 10) |||
-      ((bit &&& @file_gh_mask &&& @not_rank_8) <<< 6) |||
-      ((bit &&& @file_ab_mask &&& @not_rank_1) >>> 6) |||
-      ((bit &&& @file_gh_mask &&& @not_rank_1) >>> 10) |||
-      ((bit &&& @file_a_mask &&& @not_rank_12) >>> 15) |||
-      ((bit &&& @file_h_mask &&& @not_rank_12) >>> 17)
+    (bit &&& @file_a_mask &&& @not_rank_78) <<< 17 |||
+      (bit &&& @file_h_mask &&& @not_rank_78) <<< 15 |||
+      (bit &&& @file_ab_mask &&& @not_rank_8) <<< 10 |||
+      (bit &&& @file_gh_mask &&& @not_rank_8) <<< 6 |||
+      (bit &&& @file_ab_mask &&& @not_rank_1) >>> 6 |||
+      (bit &&& @file_gh_mask &&& @not_rank_1) >>> 10 |||
+      (bit &&& @file_a_mask &&& @not_rank_12) >>> 15 |||
+      (bit &&& @file_h_mask &&& @not_rank_12) >>> 17
   end
 
   # Squares from which a pawn of `attacker` color attacks `target`.
   # White pawns attack via <<<7 / <<<9; black via >>>7 / >>>9 (see Pawn).
   defp pawn_attackers(:white, target) do
-    ((target &&& @file_a_mask) >>> 7) ||| ((target &&& @file_h_mask) >>> 9)
+    (target &&& @file_a_mask) >>> 7 ||| (target &&& @file_h_mask) >>> 9
   end
 
   defp pawn_attackers(:black, target) do
-    ((target &&& @file_a_mask) <<< 9) ||| ((target &&& @file_h_mask) <<< 7)
+    (target &&& @file_a_mask) <<< 9 ||| (target &&& @file_h_mask) <<< 7
   end
 
   defp rook_attacks(bit, occupied) do

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -7,34 +7,12 @@ defmodule Chess.BitBoards.Pieces.King do
 
   import Bitwise
 
+  alias Chess.Bitboards.Attacks
   alias Chess.Bitboards.Move
-  alias Chess.Bitboards.Slider
   alias Chess.Boards.BitBoard
   alias Chess.Boards.Bitboards.Square
   alias Chess.Game
   alias Chess.Moves.Proposals
-
-  @knight_deltas [
-    {1, 2},
-    {2, 1},
-    {-1, 2},
-    {-2, 1},
-    {1, -2},
-    {2, -1},
-    {-1, -2},
-    {-2, -1}
-  ]
-
-  @king_deltas [
-    {-1, -1},
-    {-1, 0},
-    {-1, 1},
-    {0, -1},
-    {0, 1},
-    {1, -1},
-    {1, 0},
-    {1, 1}
-  ]
 
   @piece_types [:pawns, :rooks, :knights, :bishops, :queens, :king]
 
@@ -56,7 +34,7 @@ defmodule Chess.BitBoards.Pieces.King do
   def in_check?(board, color) do
     case king_square(board, color) do
       nil -> false
-      square -> attacked_by?(board, opponent(color), square)
+      square -> Attacks.square_attacked_by?(board, opponent(color), square)
     end
   end
 
@@ -137,94 +115,6 @@ defmodule Chess.BitBoards.Pieces.King do
   defp trailing_zeros(n, index) when (n &&& 1) == 1, do: index
   defp trailing_zeros(n, index), do: trailing_zeros(n >>> 1, index + 1)
 
-  defp attacked_by?(board, attacker, square) do
-    attacked_by_king?(board, attacker, square) or
-      attacked_by_knight?(board, attacker, square) or
-      attacked_by_pawn?(board, attacker, square) or
-      attacked_by_slider?(board, attacker, square)
-  end
-
-  defp attacked_by_king?(board, attacker, square) do
-    Enum.any?(@king_deltas, fn delta ->
-      case offset_square(square, delta) do
-        {:ok, origin} -> occupied_by_piece?(board, attacker, :king, origin)
-        :error -> false
-      end
-    end)
-  end
-
-  defp attacked_by_knight?(board, attacker, square) do
-    Enum.any?(@knight_deltas, fn delta ->
-      case offset_square(square, delta) do
-        {:ok, origin} -> occupied_by_piece?(board, attacker, :knights, origin)
-        :error -> false
-      end
-    end)
-  end
-
-  defp attacked_by_pawn?(board, attacker, square) do
-    pawn_origins(attacker, square)
-    |> Enum.any?(fn origin -> occupied_by_piece?(board, attacker, :pawns, origin) end)
-  end
-
-  defp pawn_origins(:white, square) do
-    # White pawns attack one rank forward diagonally, so they sit one rank below.
-    for file_delta <- [-1, 1],
-        {:ok, origin} <- [offset_square(square, {file_delta, -1})],
-        do: origin
-  end
-
-  defp pawn_origins(:black, square) do
-    for file_delta <- [-1, 1],
-        {:ok, origin} <- [offset_square(square, {file_delta, 1})],
-        do: origin
-  end
-
-  defp attacked_by_slider?(board, attacker, square) do
-    occupied = BitBoard.get_raw(board, :full)
-
-    Enum.any?(Slider.rook().deltas ++ Slider.bishop().deltas, fn delta ->
-      case first_occupied_along(square, delta, occupied) do
-        nil ->
-          false
-
-        blocker ->
-          sliding_attacker?(board, attacker, blocker, delta)
-      end
-    end)
-  end
-
-  defp first_occupied_along(square, delta, occupied) do
-    case offset_square(square, delta) do
-      :error ->
-        nil
-
-      {:ok, next} ->
-        if (Square.bitboard(next) &&& occupied) != 0 do
-          next
-        else
-          first_occupied_along(next, delta, occupied)
-        end
-    end
-  end
-
-  defp sliding_attacker?(board, attacker, blocker, {file_delta, rank_delta}) do
-    orthogonal? = file_delta == 0 or rank_delta == 0
-
-    if orthogonal? do
-      occupied_by_piece?(board, attacker, :rooks, blocker) or
-        occupied_by_piece?(board, attacker, :queens, blocker)
-    else
-      occupied_by_piece?(board, attacker, :bishops, blocker) or
-        occupied_by_piece?(board, attacker, :queens, blocker)
-    end
-  end
-
-  defp occupied_by_piece?(board, color, piece_type, square) do
-    pieces = BitBoard.get_raw(board, {color, piece_type})
-    (pieces &&& Square.bitboard(square)) != 0
-  end
-
   defp occupied_by?(board, color, square) do
     pieces = BitBoard.get_raw(board, color)
     (pieces &&& Square.bitboard(square)) != 0
@@ -238,15 +128,5 @@ defmodule Chess.BitBoards.Pieces.King do
     rank_delta = abs(to_rank - from_rank)
 
     file_delta <= 1 and rank_delta <= 1 and {file_delta, rank_delta} != {0, 0}
-  end
-
-  defp offset_square({<<file>>, rank}, {file_delta, rank_delta}) do
-    case {<<file + file_delta>>, rank + rank_delta} do
-      {<<new_file>>, new_rank} when new_file in ?a..?h and new_rank in 1..8 ->
-        {:ok, {<<new_file>>, new_rank}}
-
-      _ ->
-        :error
-    end
   end
 end

--- a/test/chess/board/bitboards/attacks_test.exs
+++ b/test/chess/board/bitboards/attacks_test.exs
@@ -1,0 +1,127 @@
+defmodule Chess.Bitboards.AttacksTest do
+  use ExUnit.Case, async: true
+
+  alias Chess.Bitboards.Attacks
+  alias Chess.Boards.BitBoard
+  alias Chess.Boards.Bitboards.Square
+
+  describe "square_attacked_by?/3" do
+    test "detects adjacent king attacks" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 4}},
+          {{:black, :king}, {"e", 5}}
+        ])
+
+      assert Attacks.square_attacked_by?(board, :black, {"e", 4})
+    end
+
+    test "detects knight attacks without wraparound from the a-file" do
+      board =
+        board_with([
+          {{:white, :king}, {"a", 4}},
+          {{:black, :knights}, {"b", 6}}
+        ])
+
+      assert Attacks.square_attacked_by?(board, :black, {"a", 4})
+
+      # Knight on h5 must not wrap and appear to attack a4.
+      wrapped =
+        board_with([
+          {{:white, :king}, {"a", 4}},
+          {{:black, :knights}, {"h", 5}}
+        ])
+
+      refute Attacks.square_attacked_by?(wrapped, :black, {"a", 4})
+    end
+
+    test "detects black pawn attacks and ignores the wrong direction" do
+      attacked =
+        board_with([
+          {{:white, :king}, {"e", 4}},
+          {{:black, :pawns}, {"d", 5}}
+        ])
+
+      assert Attacks.square_attacked_by?(attacked, :black, {"e", 4})
+
+      behind =
+        board_with([
+          {{:white, :king}, {"e", 4}},
+          {{:black, :pawns}, {"d", 3}}
+        ])
+
+      refute Attacks.square_attacked_by?(behind, :black, {"e", 4})
+    end
+
+    test "detects white pawn reverse attacks" do
+      board =
+        board_with([
+          {{:black, :king}, {"e", 5}},
+          {{:white, :pawns}, {"d", 4}}
+        ])
+
+      assert Attacks.square_attacked_by?(board, :white, {"e", 5})
+    end
+
+    test "detects rook attacks and stops at the first blocker" do
+      open_file =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:black, :rooks}, {"e", 8}}
+        ])
+
+      assert Attacks.square_attacked_by?(open_file, :black, {"e", 1})
+
+      blocked =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:white, :pawns}, {"e", 2}},
+          {{:black, :rooks}, {"e", 8}}
+        ])
+
+      refute Attacks.square_attacked_by?(blocked, :black, {"e", 1})
+    end
+
+    test "detects bishop and queen diagonal attacks" do
+      bishop =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:black, :bishops}, {"b", 4}}
+        ])
+
+      assert Attacks.square_attacked_by?(bishop, :black, {"e", 1})
+
+      queen =
+        board_with([
+          {{:white, :king}, {"e", 4}},
+          {{:black, :queens}, {"e", 8}}
+        ])
+
+      assert Attacks.square_attacked_by?(queen, :black, {"e", 4})
+    end
+
+    test "returns false when no attacker hits the square" do
+      board = board_with([{{:white, :king}, {"e", 1}}])
+
+      refute Attacks.square_attacked_by?(board, :black, {"e", 1})
+    end
+  end
+
+  defp board_with(pieces) do
+    empty = BitBoard.empty()
+
+    empty_pieces = %{
+      pawns: empty,
+      rooks: empty,
+      knights: empty,
+      bishops: empty,
+      queens: empty,
+      king: empty
+    }
+
+    Enum.reduce(pieces, %BitBoard{white: empty_pieces, black: empty_pieces}, fn
+      {{color, piece_type}, square}, board ->
+        put_in(board[{color, piece_type}], BitBoard.from_integer(Square.bitboard(square)))
+    end)
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #55

## Summary

Extracts engine-wide attack detection out of `Chess.BitBoards.Pieces.King` into a shared `Chess.Bitboards.Attacks` module, using bitwise reverse-attack checks (shifts + file masks + occupancy rays) instead of `Enum.any?` over coordinate deltas.

## What moved

- New `Chess.Bitboards.Attacks` with `square_attacked_by?/3`
- Covers king, knight, pawn, and slider (rook/bishop/queen) reverse attacks via bitboard ops (`import Bitwise`), following the pattern in `Pawn.potential_attacks/2`
- `King.in_check?/2` is now a thin wrapper over `Attacks.square_attacked_by?/3`
- Removed Enum-based attack helpers / deltas / `offset_square` from King
- Board mutation helpers (`clear_square`, `move_piece`) stay in King for now (follow-up #56)
- Existing `King.in_check?/2` tests kept calling through King; added focused `Attacks` unit tests

## Follow-ups

- #56 Extract bitboard move application helpers onto BitBoard
- #57 Slim King module to Validator-only concerns
- #58 Add precomputed king/knight attack lookup tables (optional)

## Test results

- `mix test` — **5 properties, 198 tests, 0 failures**
- `mix test` Attacks + King — 21 tests, 0 failures
- `mix format --check-formatted` — pass
- `mix credo --strict` — no issues

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc6f744c-d409-4d3a-9b75-9644b586ee01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc6f744c-d409-4d3a-9b75-9644b586ee01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

