### PR TITLE
Extract bitboard move application helpers onto BitBoard

### DIFF
--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -10,6 +10,7 @@ defmodule Chess.Boards.BitBoard do
   import Bitwise
 
   alias Chess.Board.Coordinates
+  alias Chess.Boards.Bitboards.Square
   alias Chess.Color
 
   @behaviour Access
@@ -159,6 +160,49 @@ defmodule Chess.Boards.BitBoard do
   def from_integer(bitboard), do: <<bitboard::integer-size(64)>>
 
   @doc """
+  Clears any piece of `color` occupying the square identified by `square_mask`.
+
+  `square_mask` is a 64-bit integer with a single bit set (see `Square.bitboard/1`).
+  """
+  @spec clear_square(t(), Color.t(), integer()) :: t()
+  def clear_square(board, color, square_mask) do
+    Enum.reduce(@piece_types, board, fn piece_type, acc ->
+      <<pieces::integer-size(64)>> = acc[{color, piece_type}]
+      put_in(acc[{color, piece_type}], from_integer(pieces &&& bnot(square_mask)))
+    end)
+  end
+
+  @doc """
+  Moves a piece of `piece_type` for `color` from `from_mask` to `to_mask`.
+
+  Does not remove opponent pieces on the destination square; use
+  `apply_candidate_move/5` (or `clear_square/3` first) when simulating captures.
+  """
+  @spec move_piece(t(), Color.t(), piece_keys(), integer(), integer()) :: t()
+  def move_piece(board, color, piece_type, from_mask, to_mask) do
+    <<pieces::integer-size(64)>> = board[{color, piece_type}]
+    updated = (pieces &&& bnot(from_mask)) ||| to_mask
+    put_in(board[{color, piece_type}], from_integer(updated))
+  end
+
+  @doc """
+  Applies a candidate move for validation / king-safety simulation.
+
+  Clears any opponent piece on the destination square, then moves the given
+  piece from `from` to `to`. Does not update game metadata (move list, side to
+  move, castling rights, en passant, etc.).
+  """
+  @spec apply_candidate_move(t(), Color.t(), piece_keys(), Square.t(), Square.t()) :: t()
+  def apply_candidate_move(board, color, piece_type, from, to) do
+    from_mask = Square.bitboard(from)
+    to_mask = Square.bitboard(to)
+
+    board
+    |> clear_square(opponent(color), to_mask)
+    |> move_piece(color, piece_type, from_mask, to_mask)
+  end
+
+  @doc """
   Returns an 8x8 grid representation of a given
   bitboard. If the bitboard does not take up a full
   64 bits, the representation is padded with 0s to
@@ -222,4 +266,7 @@ defmodule Chess.Boards.BitBoard do
       false -> board
     end
   end
+
+  defp opponent(:white), do: :black
+  defp opponent(:black), do: :white
 end

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -14,8 +14,6 @@ defmodule Chess.BitBoards.Pieces.King do
   alias Chess.Game
   alias Chess.Moves.Proposals
 
-  @piece_types [:pawns, :rooks, :knights, :bishops, :queens, :king]
-
   @impl Chess.Moves.Validator
   @spec validate_move(Game.t(), Proposals.t()) :: {:ok, Move.t()} | {:error, atom()}
   def validate_move(game, %Proposals{source: source, destination: destination}) do
@@ -55,7 +53,14 @@ defmodule Chess.BitBoards.Pieces.King do
   end
 
   defp validate_king_safety(game, source, destination) do
-    board_after_move = apply_king_move(game.board, game.current_player, source, destination)
+    board_after_move =
+      BitBoard.apply_candidate_move(
+        game.board,
+        game.current_player,
+        :king,
+        source,
+        destination
+      )
 
     if in_check?(board_after_move, game.current_player) do
       {:error, :king_in_check}
@@ -72,29 +77,6 @@ defmodule Chess.BitBoards.Pieces.King do
     else
       :quiet
     end
-  end
-
-  defp apply_king_move(board, color, from, to) do
-    from_mask = Square.bitboard(from)
-    to_mask = Square.bitboard(to)
-    opponent = opponent(color)
-
-    board
-    |> clear_square(opponent, to_mask)
-    |> move_piece(color, :king, from_mask, to_mask)
-  end
-
-  defp clear_square(board, color, square_mask) do
-    Enum.reduce(@piece_types, board, fn piece_type, acc ->
-      <<pieces::integer-size(64)>> = acc[{color, piece_type}]
-      put_in(acc[{color, piece_type}], BitBoard.from_integer(pieces &&& bnot(square_mask)))
-    end)
-  end
-
-  defp move_piece(board, color, piece_type, from_mask, to_mask) do
-    <<pieces::integer-size(64)>> = board[{color, piece_type}]
-    updated = (pieces &&& bnot(from_mask)) ||| to_mask
-    put_in(board[{color, piece_type}], BitBoard.from_integer(updated))
   end
 
   defp king_square(board, color) do

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -2,6 +2,7 @@ defmodule Chess.Boards.BitBoardTest do
   use ExUnit.Case, async: true
 
   alias Chess.Boards.BitBoard
+  alias Chess.Boards.Bitboards.Square
   alias Chess.Color
 
   describe "new/0" do
@@ -352,6 +353,75 @@ defmodule Chess.Boards.BitBoardTest do
     end
   end
 
+  describe "clear_square/3" do
+    test "removes any piece of the given color from the square" do
+      board =
+        board_with([
+          {{:black, :pawns}, {"e", 5}},
+          {{:white, :king}, {"e", 1}}
+        ])
+
+      cleared = BitBoard.clear_square(board, :black, Square.bitboard({"e", 5}))
+
+      assert BitBoard.get_raw(cleared, {:black, :pawns}) == 0
+      assert BitBoard.get_raw(cleared, {:white, :king}) == Square.bitboard({"e", 1})
+    end
+  end
+
+  describe "move_piece/5" do
+    test "relocates a piece from the source mask to the destination mask" do
+      board = board_with([{{:white, :king}, {"e", 1}}])
+
+      moved =
+        BitBoard.move_piece(
+          board,
+          :white,
+          :king,
+          Square.bitboard({"e", 1}),
+          Square.bitboard({"e", 2})
+        )
+
+      assert BitBoard.get_raw(moved, {:white, :king}) == Square.bitboard({"e", 2})
+    end
+  end
+
+  describe "apply_candidate_move/5" do
+    test "moves a piece onto an empty square" do
+      board = board_with([{{:white, :king}, {"e", 1}}])
+
+      after_move = BitBoard.apply_candidate_move(board, :white, :king, {"e", 1}, {"e", 2})
+
+      assert BitBoard.get_raw(after_move, {:white, :king}) == Square.bitboard({"e", 2})
+    end
+
+    test "captures an opponent piece on the destination square" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:black, :pawns}, {"f", 2}}
+        ])
+
+      after_move = BitBoard.apply_candidate_move(board, :white, :king, {"e", 1}, {"f", 2})
+
+      assert BitBoard.get_raw(after_move, {:white, :king}) == Square.bitboard({"f", 2})
+      assert BitBoard.get_raw(after_move, {:black, :pawns}) == 0
+    end
+
+    test "does not clear friendly pieces from unrelated squares" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:white, :pawns}, {"a", 2}},
+          {{:black, :rooks}, {"h", 8}}
+        ])
+
+      after_move = BitBoard.apply_candidate_move(board, :white, :king, {"e", 1}, {"d", 1})
+
+      assert BitBoard.get_raw(after_move, {:white, :pawns}) == Square.bitboard({"a", 2})
+      assert BitBoard.get_raw(after_move, {:black, :rooks}) == Square.bitboard({"h", 8})
+    end
+  end
+
   describe "Access Behaviour" do
     test "fetch/2 accepts a valid {color, piece_type} tuple and returns {:ok, piece_bitboard}" do
       bitboard = BitBoard.new()
@@ -436,5 +506,23 @@ defmodule Chess.Boards.BitBoardTest do
         BitBoard.pop(BitBoard.new(), {:white, :pawns})
       end
     end
+  end
+
+  defp board_with(pieces) do
+    empty = BitBoard.empty()
+
+    empty_pieces = %{
+      pawns: empty,
+      rooks: empty,
+      knights: empty,
+      bishops: empty,
+      queens: empty,
+      king: empty
+    }
+
+    Enum.reduce(pieces, %BitBoard{white: empty_pieces, black: empty_pieces}, fn
+      {{color, piece_type}, square}, board ->
+        put_in(board[{color, piece_type}], BitBoard.from_integer(Square.bitboard(square)))
+    end)
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #56

## Summary

Moves board mutation helpers out of `Chess.BitBoards.Pieces.King` onto `Chess.Boards.BitBoard` so every piece `Validator` can share simulate-then-check-king-safety without duplicating mutation logic.

## API

Added to `Chess.Boards.BitBoard`:

- `clear_square/3` — clear any piece of a color from a square mask
- `move_piece/5` — relocate a piece type between square masks
- `apply_candidate_move/5` — capture-aware candidate simulation (`from`/`to` coordinates)

## Changes

- King king-safety validation now calls `BitBoard.apply_candidate_move/5`
- Removed private `clear_square`, `move_piece`, and `apply_king_move` from King
- Added focused BitBoard unit tests for quiet moves and captures

## Test results

- `mix test` — **5 properties, 203 tests, 0 failures**
- `mix format --check-formatted` — pass
- `mix credo --strict` — no issues

## Follow-ups

- #57 Slim King module to Validator-only concerns
- Other piece modules can call `apply_candidate_move/5` when implementing `validate_move/2`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b95-46f3-710a-b624-daeab3265de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b95-46f3-710a-b624-daeab3265de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

