### PR TITLE
Slim King module to Validator-only concerns (#57)

### DIFF
--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -198,7 +198,7 @@ defmodule Chess.Boards.BitBoard do
     to_mask = Square.bitboard(to)
 
     board
-    |> clear_square(opponent(color), to_mask)
+    |> clear_square(Color.opponent(color), to_mask)
     |> move_piece(color, piece_type, from_mask, to_mask)
   end
 
@@ -266,7 +266,4 @@ defmodule Chess.Boards.BitBoard do
       false -> board
     end
   end
-
-  defp opponent(:white), do: :black
-  defp opponent(:black), do: :white
 end

--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -10,7 +10,6 @@ defmodule Chess.Boards.BitBoard do
   import Bitwise
 
   alias Chess.Board.Coordinates
-  alias Chess.Boards.Bitboards.Square
   alias Chess.Color
 
   @behaviour Access
@@ -176,30 +175,14 @@ defmodule Chess.Boards.BitBoard do
   Moves a piece of `piece_type` for `color` from `from_mask` to `to_mask`.
 
   Does not remove opponent pieces on the destination square; use
-  `apply_candidate_move/5` (or `clear_square/3` first) when simulating captures.
+  `Chess.Game.apply_candidate_move/4` (or `clear_square/3` first) when
+  simulating captures.
   """
   @spec move_piece(t(), Color.t(), piece_keys(), integer(), integer()) :: t()
   def move_piece(board, color, piece_type, from_mask, to_mask) do
     <<pieces::integer-size(64)>> = board[{color, piece_type}]
     updated = (pieces &&& bnot(from_mask)) ||| to_mask
     put_in(board[{color, piece_type}], from_integer(updated))
-  end
-
-  @doc """
-  Applies a candidate move for validation / king-safety simulation.
-
-  Clears any opponent piece on the destination square, then moves the given
-  piece from `from` to `to`. Does not update game metadata (move list, side to
-  move, castling rights, en passant, etc.).
-  """
-  @spec apply_candidate_move(t(), Color.t(), piece_keys(), Square.t(), Square.t()) :: t()
-  def apply_candidate_move(board, color, piece_type, from, to) do
-    from_mask = Square.bitboard(from)
-    to_mask = Square.bitboard(to)
-
-    board
-    |> clear_square(Color.opponent(color), to_mask)
-    |> move_piece(color, piece_type, from_mask, to_mask)
   end
 
   @doc """

--- a/lib/chess/board/bitboards/move.ex
+++ b/lib/chess/board/bitboards/move.ex
@@ -41,6 +41,8 @@ defmodule Chess.Bitboards.Move do
   """
   import Bitwise
 
+  alias Chess.Boards.BitBoard
+
   defstruct [:from, :to, :flag]
 
   @flag_codes %{
@@ -116,6 +118,25 @@ defmodule Chess.Bitboards.Move do
 
   @spec flags() :: list(flag())
   def flags, do: Map.keys(@flag_codes)
+
+  @doc """
+  Returns `:captures` when `destination` is occupied by an opponent of `color`,
+  otherwise `:quiet`.
+
+  Shared by piece validators for ordinary non-special moves. Piece-specific
+  flags (castling, double pawn push, promotions, en passant) should be chosen
+  by the piece module before falling back to this helper.
+  """
+  @spec quiet_or_capture(BitBoard.t(), Chess.player(), coordinate()) :: :quiet | :captures
+  def quiet_or_capture(board, color, destination) do
+    opponent = opponent(color)
+
+    if BitBoard.square_occupied?(BitBoard.get(board, opponent), destination) do
+      :captures
+    else
+      :quiet
+    end
+  end
 
   @file_to_value ?a..?h |> Enum.with_index() |> Map.new(fn {k, v} -> {<<k>>, v} end)
   @value_to_file Map.new(@file_to_value, fn {file, value} -> {value, file} end)
@@ -200,4 +221,7 @@ defmodule Chess.Bitboards.Move do
       flag -> {:ok, flag}
     end
   end
+
+  defp opponent(:white), do: :black
+  defp opponent(:black), do: :white
 end

--- a/lib/chess/board/bitboards/move.ex
+++ b/lib/chess/board/bitboards/move.ex
@@ -42,6 +42,7 @@ defmodule Chess.Bitboards.Move do
   import Bitwise
 
   alias Chess.Boards.BitBoard
+  alias Chess.Game
 
   defstruct [:from, :to, :flag]
 
@@ -120,22 +121,24 @@ defmodule Chess.Bitboards.Move do
   def flags, do: Map.keys(@flag_codes)
 
   @doc """
-  Returns `:captures` when `destination` is occupied by an opponent of `color`,
-  otherwise `:quiet`.
+  Builds a move from `from` to `to` for the side to move in `game`.
 
-  Shared by piece validators for ordinary non-special moves. Piece-specific
-  flags (castling, double pawn push, promotions, en passant) should be chosen
-  by the piece module before falling back to this helper.
+  Sets the flag to `:captures` when the destination is occupied by the
+  opponent, otherwise `:quiet`. Piece-specific flags (castling, double
+  pawn push, promotions, en passant) should be supplied by the piece
+  module via `make/4`.
   """
-  @spec quiet_or_capture(BitBoard.t(), Chess.player(), coordinate()) :: :quiet | :captures
-  def quiet_or_capture(board, color, destination) do
-    opponent = opponent(color)
+  @spec make(Game.t(), coordinate(), coordinate()) :: t()
+  def make(%Game{} = game, from, to) do
+    make(game, from, to, quiet_or_capture(game, to))
+  end
 
-    if BitBoard.square_occupied?(BitBoard.get(board, opponent), destination) do
-      :captures
-    else
-      :quiet
-    end
+  @doc """
+  Builds a move with an explicit `flag`.
+  """
+  @spec make(Game.t(), coordinate(), coordinate(), flag()) :: t()
+  def make(%Game{}, from, to, flag) do
+    %__MODULE__{from: from, to: to, flag: flag}
   end
 
   @file_to_value ?a..?h |> Enum.with_index() |> Map.new(fn {k, v} -> {<<k>>, v} end)
@@ -222,6 +225,11 @@ defmodule Chess.Bitboards.Move do
     end
   end
 
-  defp opponent(:white), do: :black
-  defp opponent(:black), do: :white
+  defp quiet_or_capture(%Game{} = game, destination) do
+    if BitBoard.square_occupied?(BitBoard.get(game.board, Game.opponent(game)), destination) do
+      :captures
+    else
+      :quiet
+    end
+  end
 end

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -22,7 +22,8 @@ defmodule Chess.BitBoards.Pieces.King do
     with :ok <- validate_geometry(source, destination),
          :ok <- validate_not_self_capture(game, destination),
          :ok <- validate_king_safety(game, source, destination) do
-      {:ok, %Move{from: source, to: destination, flag: move_flag(game, destination)}}
+      flag = Move.quiet_or_capture(game.board, game.current_player, destination)
+      {:ok, %Move{from: source, to: destination, flag: flag}}
     end
   end
 
@@ -68,16 +69,6 @@ defmodule Chess.BitBoards.Pieces.King do
       {:error, :king_in_check}
     else
       :ok
-    end
-  end
-
-  defp move_flag(game, destination) do
-    opponent = opponent(game.current_player)
-
-    if occupied_by?(game.board, opponent, destination) do
-      :captures
-    else
-      :quiet
     end
   end
 

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -1,11 +1,13 @@
 defmodule Chess.BitBoards.Pieces.King do
   @moduledoc """
-  Functions for generating and validating king moves on a bitboard.
+  King move validation (`Chess.Moves.Validator`).
+
+  Orchestrates geometry, self-capture, and king-safety checks. Attack
+  detection lives in `Chess.Bitboards.Attacks`; candidate-move simulation
+  lives on `Chess.Boards.BitBoard`. Castling is reserved for a follow-up.
   """
 
   @behaviour Chess.Moves.Validator
-
-  import Bitwise
 
   alias Chess.Bitboards.Attacks
   alias Chess.Bitboards.Move
@@ -80,26 +82,15 @@ defmodule Chess.BitBoards.Pieces.King do
   end
 
   defp king_square(board, color) do
-    case BitBoard.get_raw(board, {color, :king}) do
-      0 -> nil
-      king_bits -> bit_to_square(king_bits)
-    end
+    board
+    |> BitBoard.get_raw({color, :king})
+    |> Square.from_bitboard()
   end
-
-  defp bit_to_square(bits) do
-    bit_index = trailing_zeros(bits)
-    rank = div(bit_index, 8) + 1
-    file = Enum.at(~w(h g f e d c b a), rem(bit_index, 8))
-    {file, rank}
-  end
-
-  defp trailing_zeros(n), do: trailing_zeros(n, 0)
-  defp trailing_zeros(n, index) when (n &&& 1) == 1, do: index
-  defp trailing_zeros(n, index), do: trailing_zeros(n >>> 1, index + 1)
 
   defp occupied_by?(board, color, square) do
-    pieces = BitBoard.get_raw(board, color)
-    (pieces &&& Square.bitboard(square)) != 0
+    board
+    |> BitBoard.get(color)
+    |> BitBoard.square_occupied?(square)
   end
 
   defp opponent(:white), do: :black

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -13,6 +13,7 @@ defmodule Chess.BitBoards.Pieces.King do
   alias Chess.Bitboards.Move
   alias Chess.Boards.BitBoard
   alias Chess.Boards.Bitboards.Square
+  alias Chess.Color
   alias Chess.Game
   alias Chess.Moves.Proposals
 
@@ -22,8 +23,7 @@ defmodule Chess.BitBoards.Pieces.King do
     with :ok <- validate_geometry(source, destination),
          :ok <- validate_not_self_capture(game, destination),
          :ok <- validate_king_safety(game, source, destination) do
-      flag = Move.quiet_or_capture(game.board, game.current_player, destination)
-      {:ok, %Move{from: source, to: destination, flag: flag}}
+      {:ok, Move.make(game, source, destination)}
     end
   end
 
@@ -35,7 +35,7 @@ defmodule Chess.BitBoards.Pieces.King do
   def in_check?(board, color) do
     case king_square(board, color) do
       nil -> false
-      square -> Attacks.square_attacked_by?(board, opponent(color), square)
+      square -> Attacks.square_attacked_by?(board, Color.opponent(color), square)
     end
   end
 
@@ -83,9 +83,6 @@ defmodule Chess.BitBoards.Pieces.King do
     |> BitBoard.get(color)
     |> BitBoard.square_occupied?(square)
   end
-
-  defp opponent(:white), do: :black
-  defp opponent(:black), do: :white
 
   defp king_step?({<<from_file>>, from_rank}, {<<to_file>>, to_rank}) do
     file_delta = abs(to_file - from_file)

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -13,7 +13,6 @@ defmodule Chess.BitBoards.Pieces.King do
   alias Chess.Bitboards.Move
   alias Chess.Boards.BitBoard
   alias Chess.Boards.Bitboards.Square
-  alias Chess.Color
   alias Chess.Game
   alias Chess.Moves.Proposals
 
@@ -28,14 +27,13 @@ defmodule Chess.BitBoards.Pieces.King do
   end
 
   @doc """
-  Returns true if the king of the given color is under attack
-  in the given board position.
+  Returns true if the side to move's king is under attack in `game`.
   """
-  @spec in_check?(BitBoard.t(), Chess.player()) :: boolean()
-  def in_check?(board, color) do
-    case king_square(board, color) do
+  @spec in_check?(Game.t()) :: boolean()
+  def in_check?(%Game{} = game) do
+    case king_square(game.board, game.current_player) do
       nil -> false
-      square -> Attacks.square_attacked_by?(board, Color.opponent(color), square)
+      square -> Attacks.square_attacked_by?(game.board, Game.opponent(game), square)
     end
   end
 
@@ -56,16 +54,7 @@ defmodule Chess.BitBoards.Pieces.King do
   end
 
   defp validate_king_safety(game, source, destination) do
-    board_after_move =
-      BitBoard.apply_candidate_move(
-        game.board,
-        game.current_player,
-        :king,
-        source,
-        destination
-      )
-
-    if in_check?(board_after_move, game.current_player) do
+    if game |> Game.apply_candidate_move(:king, source, destination) |> in_check?() do
       {:error, :king_in_check}
     else
       :ok

--- a/lib/chess/board/bitboards/square.ex
+++ b/lib/chess/board/bitboards/square.ex
@@ -39,4 +39,24 @@ defmodule Chess.Boards.Bitboards.Square do
 
     1 <<< (rank_offset + file_index)
   end
+
+  @doc """
+  Converts a single-bit bitboard integer to a square coordinate.
+
+  Returns `nil` when no bits are set. When multiple bits are set, returns
+  the square corresponding to the least-significant set bit.
+  """
+  @spec from_bitboard(integer()) :: t() | nil
+  def from_bitboard(0), do: nil
+
+  def from_bitboard(bits) when is_integer(bits) and bits > 0 do
+    bit_index = trailing_zeros(bits)
+    rank = div(bit_index, 8) + 1
+    file = Enum.at(~w(h g f e d c b a), rem(bit_index, 8))
+    {file, rank}
+  end
+
+  defp trailing_zeros(n), do: trailing_zeros(n, 0)
+  defp trailing_zeros(n, index) when (n &&& 1) == 1, do: index
+  defp trailing_zeros(n, index), do: trailing_zeros(n >>> 1, index + 1)
 end

--- a/lib/chess/color.ex
+++ b/lib/chess/color.ex
@@ -8,11 +8,4 @@ defmodule Chess.Color do
 
   def white, do: :white
   def black, do: :black
-
-  @doc """
-  Returns the opposing color.
-  """
-  @spec opponent(t()) :: t()
-  def opponent(:white), do: :black
-  def opponent(:black), do: :white
 end

--- a/lib/chess/color.ex
+++ b/lib/chess/color.ex
@@ -8,4 +8,11 @@ defmodule Chess.Color do
 
   def white, do: :white
   def black, do: :black
+
+  @doc """
+  Returns the opposing color.
+  """
+  @spec opponent(t()) :: t()
+  def opponent(:white), do: :black
+  def opponent(:black), do: :white
 end

--- a/lib/chess/game.ex
+++ b/lib/chess/game.ex
@@ -5,6 +5,7 @@ defmodule Chess.Game do
   """
   alias Chess.Bitboards.Move
   alias Chess.Boards.BitBoard
+  alias Chess.Boards.Bitboards.Square
   alias Chess.Color
 
   defstruct board: BitBoard.new(),
@@ -28,6 +29,32 @@ defmodule Chess.Game do
   @spec opponent(t()) :: Chess.player()
   def opponent(%__MODULE__{current_player: :white}), do: :black
   def opponent(%__MODULE__{current_player: :black}), do: :white
+
+  @doc """
+  Applies a candidate move for validation / king-safety simulation.
+
+  Clears any opponent piece on the destination square, then moves the given
+  piece for the side to move from `from` to `to`. Returns a game with the
+  updated board only — move list, side to move, castling rights, en passant,
+  etc. are left unchanged.
+  """
+  @spec apply_candidate_move(t(), atom(), Square.t(), Square.t()) :: t()
+  def apply_candidate_move(
+        %__MODULE__{board: board, current_player: color} = game,
+        piece_type,
+        from,
+        to
+      ) do
+    from_mask = Square.bitboard(from)
+    to_mask = Square.bitboard(to)
+
+    updated_board =
+      board
+      |> BitBoard.clear_square(opponent(game), to_mask)
+      |> BitBoard.move_piece(color, piece_type, from_mask, to_mask)
+
+    %{game | board: updated_board}
+  end
 
   ##########################################
   # Tentative interface for game play here #

--- a/lib/chess/game.ex
+++ b/lib/chess/game.ex
@@ -22,6 +22,13 @@ defmodule Chess.Game do
   """
   def new, do: %__MODULE__{}
 
+  @doc """
+  Returns the opposing side to the game's current player.
+  """
+  @spec opponent(t()) :: Chess.player()
+  def opponent(%__MODULE__{current_player: :white}), do: :black
+  def opponent(%__MODULE__{current_player: :black}), do: :white
+
   ##########################################
   # Tentative interface for game play here #
   # Let's start implementing the Proposals #

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -385,43 +385,6 @@ defmodule Chess.Boards.BitBoardTest do
     end
   end
 
-  describe "apply_candidate_move/5" do
-    test "moves a piece onto an empty square" do
-      board = board_with([{{:white, :king}, {"e", 1}}])
-
-      after_move = BitBoard.apply_candidate_move(board, :white, :king, {"e", 1}, {"e", 2})
-
-      assert BitBoard.get_raw(after_move, {:white, :king}) == Square.bitboard({"e", 2})
-    end
-
-    test "captures an opponent piece on the destination square" do
-      board =
-        board_with([
-          {{:white, :king}, {"e", 1}},
-          {{:black, :pawns}, {"f", 2}}
-        ])
-
-      after_move = BitBoard.apply_candidate_move(board, :white, :king, {"e", 1}, {"f", 2})
-
-      assert BitBoard.get_raw(after_move, {:white, :king}) == Square.bitboard({"f", 2})
-      assert BitBoard.get_raw(after_move, {:black, :pawns}) == 0
-    end
-
-    test "does not clear friendly pieces from unrelated squares" do
-      board =
-        board_with([
-          {{:white, :king}, {"e", 1}},
-          {{:white, :pawns}, {"a", 2}},
-          {{:black, :rooks}, {"h", 8}}
-        ])
-
-      after_move = BitBoard.apply_candidate_move(board, :white, :king, {"e", 1}, {"d", 1})
-
-      assert BitBoard.get_raw(after_move, {:white, :pawns}) == Square.bitboard({"a", 2})
-      assert BitBoard.get_raw(after_move, {:black, :rooks}) == Square.bitboard({"h", 8})
-    end
-  end
-
   describe "Access Behaviour" do
     test "fetch/2 accepts a valid {color, piece_type} tuple and returns {:ok, piece_bitboard}" do
       bitboard = BitBoard.new()

--- a/test/chess/board/bitboards/move_test.exs
+++ b/test/chess/board/bitboards/move_test.exs
@@ -3,6 +3,8 @@ defmodule Chess.Bitboards.MoveTest do
   use ExUnitProperties
 
   alias Chess.Bitboards.Move
+  alias Chess.Boards.BitBoard
+  alias Chess.Boards.Bitboards.Square
 
   describe "flags/0" do
     test "returns the list of all possible move flags" do
@@ -31,6 +33,34 @@ defmodule Chess.Bitboards.MoveTest do
 
              #{inspect(Move.flags())}
              """
+    end
+  end
+
+  describe "quiet_or_capture/3" do
+    test "returns :quiet when the destination is empty" do
+      board = board_with([{{:white, :king}, {"e", 1}}])
+
+      assert Move.quiet_or_capture(board, :white, {"e", 2}) == :quiet
+    end
+
+    test "returns :captures when the destination has an opponent piece" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:black, :pawns}, {"f", 2}}
+        ])
+
+      assert Move.quiet_or_capture(board, :white, {"f", 2}) == :captures
+    end
+
+    test "returns :quiet when the destination has a friendly piece" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:white, :pawns}, {"e", 2}}
+        ])
+
+      assert Move.quiet_or_capture(board, :white, {"e", 2}) == :quiet
     end
   end
 
@@ -74,5 +104,23 @@ defmodule Chess.Bitboards.MoveTest do
         flag: flag
       }
     end
+  end
+
+  defp board_with(pieces) do
+    empty = BitBoard.empty()
+
+    empty_pieces = %{
+      pawns: empty,
+      rooks: empty,
+      knights: empty,
+      bishops: empty,
+      queens: empty,
+      king: empty
+    }
+
+    Enum.reduce(pieces, %BitBoard{white: empty_pieces, black: empty_pieces}, fn
+      {{color, piece_type}, square}, board ->
+        put_in(board[{color, piece_type}], BitBoard.from_integer(Square.bitboard(square)))
+    end)
   end
 end

--- a/test/chess/board/bitboards/move_test.exs
+++ b/test/chess/board/bitboards/move_test.exs
@@ -5,6 +5,7 @@ defmodule Chess.Bitboards.MoveTest do
   alias Chess.Bitboards.Move
   alias Chess.Boards.BitBoard
   alias Chess.Boards.Bitboards.Square
+  alias Chess.Game
 
   describe "flags/0" do
     test "returns the list of all possible move flags" do
@@ -36,31 +37,43 @@ defmodule Chess.Bitboards.MoveTest do
     end
   end
 
-  describe "quiet_or_capture/3" do
-    test "returns :quiet when the destination is empty" do
-      board = board_with([{{:white, :king}, {"e", 1}}])
+  describe "make/3" do
+    test "builds a quiet move when the destination is empty" do
+      game = game_with([{{:white, :king}, {"e", 1}}])
 
-      assert Move.quiet_or_capture(board, :white, {"e", 2}) == :quiet
+      assert %Move{from: {"e", 1}, to: {"e", 2}, flag: :quiet} =
+               Move.make(game, {"e", 1}, {"e", 2})
     end
 
-    test "returns :captures when the destination has an opponent piece" do
-      board =
-        board_with([
+    test "builds a capture when the destination has an opponent piece" do
+      game =
+        game_with([
           {{:white, :king}, {"e", 1}},
           {{:black, :pawns}, {"f", 2}}
         ])
 
-      assert Move.quiet_or_capture(board, :white, {"f", 2}) == :captures
+      assert %Move{from: {"e", 1}, to: {"f", 2}, flag: :captures} =
+               Move.make(game, {"e", 1}, {"f", 2})
     end
 
-    test "returns :quiet when the destination has a friendly piece" do
-      board =
-        board_with([
+    test "builds a quiet move when the destination has a friendly piece" do
+      game =
+        game_with([
           {{:white, :king}, {"e", 1}},
           {{:white, :pawns}, {"e", 2}}
         ])
 
-      assert Move.quiet_or_capture(board, :white, {"e", 2}) == :quiet
+      assert %Move{from: {"e", 1}, to: {"e", 2}, flag: :quiet} =
+               Move.make(game, {"e", 1}, {"e", 2})
+    end
+  end
+
+  describe "make/4" do
+    test "uses the explicit flag" do
+      game = game_with([{{:white, :king}, {"e", 1}}])
+
+      assert %Move{from: {"e", 1}, to: {"g", 1}, flag: :king_castle} =
+               Move.make(game, {"e", 1}, {"g", 1}, :king_castle)
     end
   end
 
@@ -104,6 +117,10 @@ defmodule Chess.Bitboards.MoveTest do
         flag: flag
       }
     end
+  end
+
+  defp game_with(pieces) do
+    %Game{board: board_with(pieces)}
   end
 
   defp board_with(pieces) do

--- a/test/chess/board/bitboards/pieces/king_test.exs
+++ b/test/chess/board/bitboards/pieces/king_test.exs
@@ -234,77 +234,81 @@ defmodule Chess.BitBoards.Pieces.KingTest do
     end
   end
 
-  describe "in_check?/2" do
+  describe "in_check?/1" do
     test "returns false when the king is not under attack" do
-      board = board_with([{{:white, :king}, {"e", 1}}])
+      game = game_with([{{:white, :king}, {"e", 1}}])
 
-      refute King.in_check?(board, :white)
+      refute King.in_check?(game)
     end
 
     test "returns true when an opponent rook attacks the king" do
-      board =
-        board_with([
+      game =
+        game_with([
           {{:white, :king}, {"e", 1}},
           {{:black, :rooks}, {"e", 8}}
         ])
 
-      assert King.in_check?(board, :white)
+      assert King.in_check?(game)
     end
 
     test "returns false when a friendly piece blocks an opponent rook" do
-      board =
-        board_with([
+      game =
+        game_with([
           {{:white, :king}, {"e", 1}},
           {{:white, :pawns}, {"e", 2}},
           {{:black, :rooks}, {"e", 8}}
         ])
 
-      refute King.in_check?(board, :white)
+      refute King.in_check?(game)
     end
 
     test "returns true when an opponent bishop attacks the king diagonally" do
-      board =
-        board_with([
+      game =
+        game_with([
           {{:white, :king}, {"e", 1}},
           {{:black, :bishops}, {"b", 4}}
         ])
 
-      assert King.in_check?(board, :white)
+      assert King.in_check?(game)
     end
 
     test "returns true when an opponent knight attacks the king" do
-      board =
-        board_with([
+      game =
+        game_with([
           {{:white, :king}, {"e", 4}},
           {{:black, :knights}, {"d", 6}}
         ])
 
-      assert King.in_check?(board, :white)
+      assert King.in_check?(game)
     end
 
     test "returns true when an opponent pawn attacks the king" do
-      board =
-        board_with([
+      game =
+        game_with([
           {{:white, :king}, {"e", 4}},
           {{:black, :pawns}, {"d", 5}}
         ])
 
-      assert King.in_check?(board, :white)
+      assert King.in_check?(game)
     end
 
     test "returns true when an opponent king is adjacent" do
-      board =
-        board_with([
+      game =
+        game_with([
           {{:white, :king}, {"e", 4}},
           {{:black, :king}, {"e", 5}}
         ])
 
-      assert King.in_check?(board, :white)
+      assert King.in_check?(game)
     end
   end
 
   defp game_with_white_king_on(square) do
-    %Game{board: board_with([{{:white, :king}, square}])}
+    game_with([{{:white, :king}, square}])
+  end
+
+  defp game_with(pieces) do
+    %Game{board: board_with(pieces)}
   end
 
   defp board_with(pieces) do

--- a/test/chess/board/bitboards/square_test.exs
+++ b/test/chess/board/bitboards/square_test.exs
@@ -51,4 +51,27 @@ defmodule Chess.Boards.Bitboards.SquareTest do
       end
     end
   end
+
+  describe "from_bitboard/1" do
+    test "returns nil when no bits are set" do
+      assert Square.from_bitboard(0) == nil
+    end
+
+    squares =
+      for rank <- 1..8, file <- ?h..?a//-1 do
+        {<<file>>, rank}
+      end
+
+    for {square, index} <- Enum.with_index(squares) do
+      test "round-trips #{inspect(square)} through bitboard/1" do
+        assert Square.from_bitboard(1 <<< unquote(index)) == unquote(square)
+        assert Square.from_bitboard(Square.bitboard(unquote(square))) == unquote(square)
+      end
+    end
+
+    test "returns the least-significant set bit when multiple bits are set" do
+      assert Square.from_bitboard(Square.bitboard({"h", 1}) ||| Square.bitboard({"a", 8})) ==
+               {"h", 1}
+    end
+  end
 end

--- a/test/chess/game_test.exs
+++ b/test/chess/game_test.exs
@@ -11,4 +11,14 @@ defmodule Chess.GameTest do
                Game.new()
     end
   end
+
+  describe "opponent/1" do
+    test "returns black when white is to move" do
+      assert Game.opponent(%Game{current_player: :white}) == :black
+    end
+
+    test "returns white when black is to move" do
+      assert Game.opponent(%Game{current_player: :black}) == :white
+    end
+  end
 end

--- a/test/chess/game_test.exs
+++ b/test/chess/game_test.exs
@@ -2,6 +2,7 @@ defmodule Chess.GameTest do
   use ExUnit.Case
 
   alias Chess.Boards.BitBoard
+  alias Chess.Boards.Bitboards.Square
   alias Chess.Color
   alias Chess.Game
 
@@ -20,5 +21,64 @@ defmodule Chess.GameTest do
     test "returns white when black is to move" do
       assert Game.opponent(%Game{current_player: :black}) == :white
     end
+  end
+
+  describe "apply_candidate_move/4" do
+    test "moves a piece onto an empty square" do
+      game = game_with([{{:white, :king}, {"e", 1}}])
+
+      after_move = Game.apply_candidate_move(game, :king, {"e", 1}, {"e", 2})
+
+      assert BitBoard.get_raw(after_move.board, {:white, :king}) == Square.bitboard({"e", 2})
+    end
+
+    test "captures an opponent piece on the destination square" do
+      game =
+        game_with([
+          {{:white, :king}, {"e", 1}},
+          {{:black, :pawns}, {"f", 2}}
+        ])
+
+      after_move = Game.apply_candidate_move(game, :king, {"e", 1}, {"f", 2})
+
+      assert BitBoard.get_raw(after_move.board, {:white, :king}) == Square.bitboard({"f", 2})
+      assert BitBoard.get_raw(after_move.board, {:black, :pawns}) == 0
+    end
+
+    test "does not clear friendly pieces from unrelated squares" do
+      game =
+        game_with([
+          {{:white, :king}, {"e", 1}},
+          {{:white, :pawns}, {"a", 2}},
+          {{:black, :rooks}, {"h", 8}}
+        ])
+
+      after_move = Game.apply_candidate_move(game, :king, {"e", 1}, {"d", 1})
+
+      assert BitBoard.get_raw(after_move.board, {:white, :pawns}) == Square.bitboard({"a", 2})
+      assert BitBoard.get_raw(after_move.board, {:black, :rooks}) == Square.bitboard({"h", 8})
+    end
+  end
+
+  defp game_with(pieces) do
+    %Game{board: board_with(pieces)}
+  end
+
+  defp board_with(pieces) do
+    empty = BitBoard.empty()
+
+    empty_pieces = %{
+      pawns: empty,
+      rooks: empty,
+      knights: empty,
+      bishops: empty,
+      queens: empty,
+      king: empty
+    }
+
+    Enum.reduce(pieces, %BitBoard{white: empty_pieces, black: empty_pieces}, fn
+      {{color, piece_type}, square}, board ->
+        put_in(board[{color, piece_type}], BitBoard.from_integer(Square.bitboard(square)))
+    end)
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #57

## Summary

After Attacks (#59) and BitBoard move-application helpers (#60), finish slimming `Chess.BitBoards.Pieces.King` to Validator-only orchestration.

## Changes

- King validates, then returns `{:ok, Move.make(game, source, destination)}`
- `Move.make/3` (quiet/capture from game) and `Move.make/4` (explicit flag)
- `Game.opponent/1` is the sole opponent helper; `Color.opponent/1` removed
- `King.in_check?/1` and `Game.apply_candidate_move/4` take a full `Game` (candidate simulation moved onto Game to avoid a BitBoard↔Game compile cycle)
- Square decoding via `Square.from_bitboard/1`

## Test results

- `mix format --check-formatted` — pass
- `mix credo --strict` — no issues
- `mix test` — **5 properties, 275 tests, 0 failures**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9ca8-2e9b-74cb-a626-7b8e07193f5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9ca8-2e9b-74cb-a626-7b8e07193f5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

