### PR TITLE
Add precomputed king/knight attack lookup tables

### DIFF
--- a/lib/chess/board/bitboards/attacks.ex
+++ b/lib/chess/board/bitboards/attacks.ex
@@ -7,6 +7,10 @@ defmodule Chess.Bitboards.Attacks do
   opponent piece bitboards. Prefer this over coordinate/`Enum` iteration for
   engine hot paths such as king-safety checks.
 
+  King and knight attack sets are position-independent aside from board edges,
+  so they are precomputed at compile time into 64-entry lookup tables keyed by
+  square index.
+
   Bitboard layout matches the rest of the engine: bit 0 is h1, bit 7 is a1,
   bit 8 is h2, …, bit 63 is a8. Shifts toward the a-file increase the bit
   index; shifts toward the h-file decrease it.
@@ -29,6 +33,36 @@ defmodule Chess.Bitboards.Attacks do
   @not_rank_12 0b1111111111111111111111111111111111111111111111110000000000000000
   @not_rank_78 0b0000000000000000111111111111111111111111111111111111111111111111
 
+  # Compile-time tables built with the same shift + file/rank mask formulas
+  # previously evaluated at runtime. Index `n` holds attacks from bit `n`.
+  @king_attacks (for square <- 0..63 do
+                   bit = 1 <<< square
+
+                   (bit &&& @file_a_mask &&& @not_rank_8) <<< 9 |||
+                     (bit &&& @not_rank_8) <<< 8 |||
+                     (bit &&& @file_h_mask &&& @not_rank_8) <<< 7 |||
+                     (bit &&& @file_a_mask) <<< 1 |||
+                     (bit &&& @file_h_mask) >>> 1 |||
+                     (bit &&& @file_a_mask &&& @not_rank_1) >>> 7 |||
+                     (bit &&& @not_rank_1) >>> 8 |||
+                     (bit &&& @file_h_mask &&& @not_rank_1) >>> 9
+                 end)
+                |> List.to_tuple()
+
+  @knight_attacks (for square <- 0..63 do
+                     bit = 1 <<< square
+
+                     (bit &&& @file_a_mask &&& @not_rank_78) <<< 17 |||
+                       (bit &&& @file_h_mask &&& @not_rank_78) <<< 15 |||
+                       (bit &&& @file_ab_mask &&& @not_rank_8) <<< 10 |||
+                       (bit &&& @file_gh_mask &&& @not_rank_8) <<< 6 |||
+                       (bit &&& @file_ab_mask &&& @not_rank_1) >>> 6 |||
+                       (bit &&& @file_gh_mask &&& @not_rank_1) >>> 10 |||
+                       (bit &&& @file_a_mask &&& @not_rank_12) >>> 15 |||
+                       (bit &&& @file_h_mask &&& @not_rank_12) >>> 17
+                   end)
+                  |> List.to_tuple()
+
   @doc """
   Returns true if any piece of `attacker` color attacks `square`.
   """
@@ -43,12 +77,28 @@ defmodule Chess.Bitboards.Attacks do
       attacked_by_slider?(board, attacker, target, occupied)
   end
 
+  @doc """
+  Precomputed king attack bitboard for square index `0..63` (bit 0 = h1).
+  """
+  @spec king_attacks(0..63) :: integer()
+  def king_attacks(square_index) when square_index in 0..63 do
+    elem(@king_attacks, square_index)
+  end
+
+  @doc """
+  Precomputed knight attack bitboard for square index `0..63` (bit 0 = h1).
+  """
+  @spec knight_attacks(0..63) :: integer()
+  def knight_attacks(square_index) when square_index in 0..63 do
+    elem(@knight_attacks, square_index)
+  end
+
   defp attacked_by_king?(board, attacker, target) do
-    (king_attacks(target) &&& BitBoard.get_raw(board, {attacker, :king})) != 0
+    (king_attacks(square_index(target)) &&& BitBoard.get_raw(board, {attacker, :king})) != 0
   end
 
   defp attacked_by_knight?(board, attacker, target) do
-    (knight_attacks(target) &&& BitBoard.get_raw(board, {attacker, :knights})) != 0
+    (knight_attacks(square_index(target)) &&& BitBoard.get_raw(board, {attacker, :knights})) != 0
   end
 
   defp attacked_by_pawn?(board, attacker, target) do
@@ -67,29 +117,11 @@ defmodule Chess.Bitboards.Attacks do
       (bishop_attacks(target, occupied) &&& diag) != 0
   end
 
-  # King attacks from a single-bit square (identical to reverse king attackers).
-  defp king_attacks(bit) do
-    # NW (toward a, up), N, NE (toward h, up), W, E, SW, S, SE
-    (bit &&& @file_a_mask &&& @not_rank_8) <<< 9 |||
-      (bit &&& @not_rank_8) <<< 8 |||
-      (bit &&& @file_h_mask &&& @not_rank_8) <<< 7 |||
-      (bit &&& @file_a_mask) <<< 1 |||
-      (bit &&& @file_h_mask) >>> 1 |||
-      (bit &&& @file_a_mask &&& @not_rank_1) >>> 7 |||
-      (bit &&& @not_rank_1) >>> 8 |||
-      (bit &&& @file_h_mask &&& @not_rank_1) >>> 9
-  end
+  defp square_index(bit), do: trailing_zeros(bit)
 
-  defp knight_attacks(bit) do
-    (bit &&& @file_a_mask &&& @not_rank_78) <<< 17 |||
-      (bit &&& @file_h_mask &&& @not_rank_78) <<< 15 |||
-      (bit &&& @file_ab_mask &&& @not_rank_8) <<< 10 |||
-      (bit &&& @file_gh_mask &&& @not_rank_8) <<< 6 |||
-      (bit &&& @file_ab_mask &&& @not_rank_1) >>> 6 |||
-      (bit &&& @file_gh_mask &&& @not_rank_1) >>> 10 |||
-      (bit &&& @file_a_mask &&& @not_rank_12) >>> 15 |||
-      (bit &&& @file_h_mask &&& @not_rank_12) >>> 17
-  end
+  defp trailing_zeros(n), do: trailing_zeros(n, 0)
+  defp trailing_zeros(n, index) when (n &&& 1) == 1, do: index
+  defp trailing_zeros(n, index), do: trailing_zeros(n >>> 1, index + 1)
 
   # Squares from which a pawn of `attacker` color attacks `target`.
   # White pawns attack via <<<7 / <<<9; black via >>>7 / >>>9 (see Pawn).

--- a/test/chess/board/bitboards/attacks_test.exs
+++ b/test/chess/board/bitboards/attacks_test.exs
@@ -1,9 +1,33 @@
 defmodule Chess.Bitboards.AttacksTest do
   use ExUnit.Case, async: true
 
+  import Bitwise
+
   alias Chess.Bitboards.Attacks
   alias Chess.Boards.BitBoard
   alias Chess.Boards.Bitboards.Square
+
+  @king_deltas [
+    {-1, -1},
+    {-1, 0},
+    {-1, 1},
+    {0, -1},
+    {0, 1},
+    {1, -1},
+    {1, 0},
+    {1, 1}
+  ]
+
+  @knight_deltas [
+    {1, 2},
+    {2, 1},
+    {-1, 2},
+    {-2, 1},
+    {1, -2},
+    {2, -1},
+    {-1, -2},
+    {-2, -1}
+  ]
 
   describe "square_attacked_by?/3" do
     test "detects adjacent king attacks" do
@@ -106,6 +130,92 @@ defmodule Chess.Bitboards.AttacksTest do
       refute Attacks.square_attacked_by?(board, :black, {"e", 1})
     end
   end
+
+  describe "king_attacks/1" do
+    test "matches coordinate-delta attack sets for every square index" do
+      for square_index <- 0..63 do
+        square = Square.from_bitboard(1 <<< square_index)
+        expected = attacks_from_deltas(square, @king_deltas)
+
+        assert Attacks.king_attacks(square_index) == expected,
+               "king attacks mismatch at index #{square_index} (#{inspect(square)})"
+      end
+    end
+
+    test "corner king on h1 attacks three squares" do
+      # h1 = index 0; attacks g1, g2, h2
+      assert Attacks.king_attacks(0) ==
+               (Square.bitboard({"g", 1}) ||| Square.bitboard({"g", 2}) |||
+                  Square.bitboard({"h", 2}))
+    end
+
+    test "central king on e4 attacks all eight neighbors" do
+      e4 = square_index({"e", 4})
+
+      expected =
+        [
+          {"d", 3},
+          {"d", 4},
+          {"d", 5},
+          {"e", 3},
+          {"e", 5},
+          {"f", 3},
+          {"f", 4},
+          {"f", 5}
+        ]
+        |> Enum.map(&Square.bitboard/1)
+        |> Enum.reduce(0, &|||/2)
+
+      assert Attacks.king_attacks(e4) == expected
+    end
+  end
+
+  describe "knight_attacks/1" do
+    test "matches coordinate-delta attack sets for every square index" do
+      for square_index <- 0..63 do
+        square = Square.from_bitboard(1 <<< square_index)
+        expected = attacks_from_deltas(square, @knight_deltas)
+
+        assert Attacks.knight_attacks(square_index) == expected,
+               "knight attacks mismatch at index #{square_index} (#{inspect(square)})"
+      end
+    end
+
+    test "corner knight on a1 has two attacks" do
+      a1 = square_index({"a", 1})
+
+      assert Attacks.knight_attacks(a1) ==
+               (Square.bitboard({"b", 3}) ||| Square.bitboard({"c", 2}))
+    end
+
+    test "does not wrap from the a-file to the h-file" do
+      a4 = square_index({"a", 4})
+      attacks = Attacks.knight_attacks(a4)
+
+      refute (attacks &&& Square.bitboard({"h", 5})) != 0
+      refute (attacks &&& Square.bitboard({"h", 3})) != 0
+      assert (attacks &&& Square.bitboard({"b", 6})) != 0
+      assert (attacks &&& Square.bitboard({"c", 5})) != 0
+    end
+  end
+
+  defp attacks_from_deltas(square, deltas) do
+    Enum.reduce(deltas, 0, fn delta, acc ->
+      case Square.try_delta(square, delta) do
+        {:ok, target} -> acc ||| Square.bitboard(target)
+        :error -> acc
+      end
+    end)
+  end
+
+  defp square_index(square) do
+    bits = Square.bitboard(square)
+    trailing_zeros(bits)
+  end
+
+  defp trailing_zeros(n), do: trailing_zeros(n, 0)
+  defp trailing_zeros(n, index) when (n &&& 1) == 1, do: index
+  defp trailing_zeros(n, index), do: trailing_zeros(n >>> 1, index + 1)
 
   defp board_with(pieces) do
     empty = BitBoard.empty()


### PR DESCRIPTION
## Summary
- Fixes #58 by replacing runtime shift-based king/knight attack generation in `Chess.Bitboards.Attacks` with compile-time 64-entry lookup tables keyed by square index (`0..63`, bit 0 = h1).
- Exposes public `king_attacks/1` and `knight_attacks/1` for O(1) lookups while keeping behavior identical to the previous shift + file/rank mask formulas.
- Adds exhaustive and edge-case tests verifying table entries against coordinate-delta attack sets (corners, center, a-file wraparound).

## Test plan
- [x] `mix test test/chess/board/bitboards/attacks_test.exs test/chess/board/bitboards/pieces/king_test.exs`
- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` on touched files
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)