### PR TITLE
Implement king castling validation

### DIFF
--- a/.github/scripts/pull-devcontainer-images.sh
+++ b/.github/scripts/pull-devcontainer-images.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pull_with_retry() {
+  local image="$1"
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if docker pull "$image"; then
+      return 0
+    fi
+    echo "Pull of $image failed (attempt $attempt); retrying..."
+    sleep $((attempt * 10))
+  done
+  echo "Failed to pull $image after retries"
+  return 1
+}
+
+pull_with_retry elixir:1.20.2-otp-29
+pull_with_retry postgres:17.6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,9 +21,12 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ hashFiles('''**/mix.lock''') }}
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
+
+      - name: Pull container images
+        run: bash .github/scripts/pull-devcontainer-images.sh
 
       - name: Install dependencies and compile
         uses: devcontainers/ci@v0.3
@@ -44,9 +47,12 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ hashFiles('''**/mix.lock''') }}
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
+
+      - name: Pull container images
+        run: bash .github/scripts/pull-devcontainer-images.sh
 
       - name: Run credo and format check
         uses: devcontainers/ci@v0.3
@@ -67,7 +73,7 @@ jobs:
 #          path: |
 #            deps
 #            _build
-#          key: ${{ runner.os }}-mix-${{ hashFiles('''**/mix.lock''') }}
+#          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
 #          restore-keys: |
 #            ${{ runner.os }}-mix-
 #
@@ -76,7 +82,7 @@ jobs:
 #        id: plt_cache
 #        with:
 #          path: /root/.mix
-#          key: plt-root-${{ runner.os }}-${{ hashFiles('''**/mix.lock''') }}
+#          key: plt-root-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}
 #          restore-keys: |
 #            plt-root-${{ runner.os }}-
 #
@@ -103,9 +109,12 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ hashFiles('''**/mix.lock''') }}
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
+
+      - name: Pull container images
+        run: bash .github/scripts/pull-devcontainer-images.sh
 
       - name: Run tests
         uses: devcontainers/ci@v0.3

--- a/lib/chess/board/bitboards/attacks.ex
+++ b/lib/chess/board/bitboards/attacks.ex
@@ -7,6 +7,9 @@ defmodule Chess.Bitboards.Attacks do
   opponent piece bitboards. Prefer this over coordinate/`Enum` iteration for
   engine hot paths such as king-safety checks.
 
+  For multi-square queries (e.g. castling transit), `attacks_by/2` builds the
+  forward attack bitboard for a color so callers can AND it with a mask.
+
   King and knight attack sets are position-independent aside from board edges,
   so they are precomputed at compile time into 64-entry lookup tables keyed by
   square index.
@@ -78,6 +81,38 @@ defmodule Chess.Bitboards.Attacks do
   end
 
   @doc """
+  Returns true if any square set in `mask` is attacked by `attacker`.
+
+  Computes the forward attack bitboard for `attacker` and intersects it with
+  `mask` via bitwise AND.
+  """
+  @spec mask_attacked_by?(BitBoard.t(), Chess.player(), integer()) :: boolean()
+  def mask_attacked_by?(board, attacker, mask) when is_integer(mask) do
+    (attacks_by(board, attacker) &&& mask) != 0
+  end
+
+  @doc """
+  Bitboard of all squares attacked by pieces of `attacker` color.
+  """
+  @spec attacks_by(BitBoard.t(), Chess.player()) :: integer()
+  def attacks_by(board, attacker) do
+    occupied = BitBoard.get_raw(board, :full)
+
+    ortho =
+      BitBoard.get_raw(board, {attacker, :rooks}) ||| BitBoard.get_raw(board, {attacker, :queens})
+
+    diag =
+      BitBoard.get_raw(board, {attacker, :bishops}) |||
+        BitBoard.get_raw(board, {attacker, :queens})
+
+    attacks_from_kings(BitBoard.get_raw(board, {attacker, :king})) |||
+      attacks_from_knights(BitBoard.get_raw(board, {attacker, :knights})) |||
+      attacks_from_pawns(BitBoard.get_raw(board, {attacker, :pawns}), attacker) |||
+      attacks_from_sliders(ortho, occupied, &rook_attacks/2) |||
+      attacks_from_sliders(diag, occupied, &bishop_attacks/2)
+  end
+
+  @doc """
   Precomputed king attack bitboard for square index `0..63` (bit 0 = h1).
   """
   @spec king_attacks(0..63) :: integer()
@@ -115,6 +150,45 @@ defmodule Chess.Bitboards.Attacks do
 
     (rook_attacks(target, occupied) &&& ortho) != 0 or
       (bishop_attacks(target, occupied) &&& diag) != 0
+  end
+
+  defp attacks_from_kings(bits) do
+    (bits &&& @file_a_mask &&& @not_rank_8) <<< 9 |||
+      (bits &&& @not_rank_8) <<< 8 |||
+      (bits &&& @file_h_mask &&& @not_rank_8) <<< 7 |||
+      (bits &&& @file_a_mask) <<< 1 |||
+      (bits &&& @file_h_mask) >>> 1 |||
+      (bits &&& @file_a_mask &&& @not_rank_1) >>> 7 |||
+      (bits &&& @not_rank_1) >>> 8 |||
+      (bits &&& @file_h_mask &&& @not_rank_1) >>> 9
+  end
+
+  defp attacks_from_knights(bits) do
+    (bits &&& @file_a_mask &&& @not_rank_78) <<< 17 |||
+      (bits &&& @file_h_mask &&& @not_rank_78) <<< 15 |||
+      (bits &&& @file_ab_mask &&& @not_rank_8) <<< 10 |||
+      (bits &&& @file_gh_mask &&& @not_rank_8) <<< 6 |||
+      (bits &&& @file_ab_mask &&& @not_rank_1) >>> 6 |||
+      (bits &&& @file_gh_mask &&& @not_rank_1) >>> 10 |||
+      (bits &&& @file_a_mask &&& @not_rank_12) >>> 15 |||
+      (bits &&& @file_h_mask &&& @not_rank_12) >>> 17
+  end
+
+  defp attacks_from_pawns(bits, :white) do
+    (bits &&& @file_a_mask) <<< 9 ||| (bits &&& @file_h_mask) <<< 7
+  end
+
+  defp attacks_from_pawns(bits, :black) do
+    (bits &&& @file_a_mask) >>> 7 ||| (bits &&& @file_h_mask) >>> 9
+  end
+
+  defp attacks_from_sliders(0, _occupied, _attack_fn), do: 0
+
+  defp attacks_from_sliders(pieces, occupied, attack_fn) do
+    bit = 1 <<< trailing_zeros(pieces)
+
+    attack_fn.(bit, occupied) |||
+      attacks_from_sliders(pieces &&& bnot(bit), occupied, attack_fn)
   end
 
   defp square_index(bit), do: trailing_zeros(bit)

--- a/lib/chess/board/bitboards/castling.ex
+++ b/lib/chess/board/bitboards/castling.ex
@@ -2,10 +2,10 @@ defmodule Chess.Bitboards.Castling do
   @moduledoc """
   Static castling geometry for bitboard move validation.
 
-  Owns king/rook home squares, king destinations, and the path masks of
-  squares that must be empty between king and rook. Consumers compose
-  these masks with occupancy bitboards via bitwise AND rather than
-  iterating coordinates.
+  Owns king/rook home squares, king destinations, path masks (squares that
+  must be empty), and transit masks (squares that must be unattacked).
+  Consumers compose these masks with occupancy or attack bitboards via
+  bitwise AND rather than iterating coordinates.
   """
 
   import Bitwise
@@ -54,6 +54,10 @@ defmodule Chess.Bitboards.Castling do
                 {key, squares |> Enum.map(&Square.bitboard/1) |> Enum.reduce(0, &bor/2)}
               end)
 
+  @transit_masks Map.new(@transit_squares, fn {key, squares} ->
+                   {key, squares |> Enum.map(&Square.bitboard/1) |> Enum.reduce(0, &bor/2)}
+                 end)
+
   @doc """
   Returns the king's starting square for `color`.
   """
@@ -88,10 +92,11 @@ defmodule Chess.Bitboards.Castling do
   end
 
   @doc """
-  Squares the king occupies, passes through, or lands on while castling.
+  Bitboard mask of squares the king occupies, passes through, or lands on
+  while castling — none may be attacked.
   """
-  @spec transit_squares(Color.t(), side()) :: list(Square.t())
-  def transit_squares(color, side), do: Map.fetch!(@transit_squares, {color, side})
+  @spec transit_mask(Color.t(), side()) :: integer()
+  def transit_mask(color, side), do: Map.fetch!(@transit_masks, {color, side})
 
   @doc """
   Classifies a king move from `source` to `destination` as kingside or

--- a/lib/chess/board/bitboards/castling.ex
+++ b/lib/chess/board/bitboards/castling.ex
@@ -1,0 +1,119 @@
+defmodule Chess.Bitboards.Castling do
+  @moduledoc """
+  Static castling geometry for bitboard move validation.
+
+  Owns king/rook home squares, king destinations, and the path masks of
+  squares that must be empty between king and rook. Consumers compose
+  these masks with occupancy bitboards via bitwise AND rather than
+  iterating coordinates.
+  """
+
+  import Bitwise
+
+  alias Chess.Boards.Bitboards.Square
+  alias Chess.Color
+
+  @type side() :: :kingside | :queenside
+
+  @king_homes %{
+    white: {"e", 1},
+    black: {"e", 8}
+  }
+
+  @king_destinations %{
+    {:white, :kingside} => {"g", 1},
+    {:white, :queenside} => {"c", 1},
+    {:black, :kingside} => {"g", 8},
+    {:black, :queenside} => {"c", 8}
+  }
+
+  @rook_homes %{
+    {:white, :kingside} => {"h", 1},
+    {:white, :queenside} => {"a", 1},
+    {:black, :kingside} => {"h", 8},
+    {:black, :queenside} => {"a", 8}
+  }
+
+  # Squares between king and rook that must be empty (includes king destination).
+  @path_squares %{
+    {:white, :kingside} => [{"f", 1}, {"g", 1}],
+    {:white, :queenside} => [{"b", 1}, {"c", 1}, {"d", 1}],
+    {:black, :kingside} => [{"f", 8}, {"g", 8}],
+    {:black, :queenside} => [{"b", 8}, {"c", 8}, {"d", 8}]
+  }
+
+  # King start, pass-through, and landing squares — none may be attacked.
+  @transit_squares %{
+    {:white, :kingside} => [{"e", 1}, {"f", 1}, {"g", 1}],
+    {:white, :queenside} => [{"e", 1}, {"d", 1}, {"c", 1}],
+    {:black, :kingside} => [{"e", 8}, {"f", 8}, {"g", 8}],
+    {:black, :queenside} => [{"e", 8}, {"d", 8}, {"c", 8}]
+  }
+
+  @path_masks Map.new(@path_squares, fn {key, squares} ->
+                {key, squares |> Enum.map(&Square.bitboard/1) |> Enum.reduce(0, &bor/2)}
+              end)
+
+  @doc """
+  Returns the king's starting square for `color`.
+  """
+  @spec king_home(Color.t()) :: Square.t()
+  def king_home(color), do: Map.fetch!(@king_homes, color)
+
+  @doc """
+  Returns the rook's starting square for `color` and castling `side`.
+  """
+  @spec rook_home(Color.t(), side()) :: Square.t()
+  def rook_home(color, side), do: Map.fetch!(@rook_homes, {color, side})
+
+  @doc """
+  Returns the king's destination square for `color` and castling `side`.
+  """
+  @spec king_destination(Color.t(), side()) :: Square.t()
+  def king_destination(color, side), do: Map.fetch!(@king_destinations, {color, side})
+
+  @doc """
+  Bitboard mask of squares that must be empty for `color` to castle `side`.
+  """
+  @spec path_mask(Color.t(), side()) :: integer()
+  def path_mask(color, side), do: Map.fetch!(@path_masks, {color, side})
+
+  @doc """
+  Returns true when `occupied` (raw full-board bitboard) has no pieces on the
+  castling path for `color` and `side`.
+  """
+  @spec path_clear?(integer(), Color.t(), side()) :: boolean()
+  def path_clear?(occupied, color, side) when is_integer(occupied) do
+    (occupied &&& path_mask(color, side)) == 0
+  end
+
+  @doc """
+  Squares the king occupies, passes through, or lands on while castling.
+  """
+  @spec transit_squares(Color.t(), side()) :: list(Square.t())
+  def transit_squares(color, side), do: Map.fetch!(@transit_squares, {color, side})
+
+  @doc """
+  Classifies a king move from `source` to `destination` as kingside or
+  queenside castling for `color`.
+  """
+  @spec side(Color.t(), Square.t(), Square.t()) :: {:ok, side()} | {:error, :cannot_castle}
+  def side(color, source, destination) do
+    home = king_home(color)
+    kingside = king_destination(color, :kingside)
+    queenside = king_destination(color, :queenside)
+
+    case {source, destination} do
+      {^home, ^kingside} -> {:ok, :kingside}
+      {^home, ^queenside} -> {:ok, :queenside}
+      _ -> {:error, :cannot_castle}
+    end
+  end
+
+  @doc """
+  Move flag for a successful castle on `side`.
+  """
+  @spec flag(side()) :: :king_castle | :queen_castle
+  def flag(:kingside), do: :king_castle
+  def flag(:queenside), do: :queen_castle
+end

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -2,9 +2,9 @@ defmodule Chess.BitBoards.Pieces.King do
   @moduledoc """
   King move validation (`Chess.Moves.Validator`).
 
-  Orchestrates geometry, self-capture, and king-safety checks. Attack
-  detection lives in `Chess.Bitboards.Attacks`; candidate-move simulation
-  lives on `Chess.Boards.BitBoard`. Castling is reserved for a follow-up.
+  Orchestrates geometry, self-capture, king-safety, and castling checks.
+  Attack detection lives in `Chess.Bitboards.Attacks`; candidate-move
+  simulation lives on `Chess.Boards.BitBoard`.
   """
 
   @behaviour Chess.Moves.Validator
@@ -19,10 +19,15 @@ defmodule Chess.BitBoards.Pieces.King do
   @impl Chess.Moves.Validator
   @spec validate_move(Game.t(), Proposals.t()) :: {:ok, Move.t()} | {:error, atom()}
   def validate_move(game, %Proposals{source: source, destination: destination}) do
-    with :ok <- validate_geometry(source, destination),
-         :ok <- validate_not_self_capture(game, destination),
-         :ok <- validate_king_safety(game, source, destination) do
-      {:ok, Move.make(game, source, destination)}
+    cond do
+      king_step?(source, destination) ->
+        validate_king_step(game, source, destination)
+
+      castling_geometry?(source, destination) ->
+        validate_castling(game, source, destination)
+
+      true ->
+        {:error, :invalid_geometry}
     end
   end
 
@@ -37,11 +42,19 @@ defmodule Chess.BitBoards.Pieces.King do
     end
   end
 
-  defp validate_geometry(source, destination) do
-    if king_step?(source, destination) do
-      :ok
-    else
-      {:error, :invalid_geometry}
+  defp validate_king_step(game, source, destination) do
+    with :ok <- validate_not_self_capture(game, destination),
+         :ok <- validate_king_safety(game, source, destination) do
+      {:ok, Move.make(game, source, destination)}
+    end
+  end
+
+  defp validate_castling(game, source, destination) do
+    with {:ok, side} <- castling_side(game.current_player, source, destination),
+         :ok <- validate_castling_rights(game, side),
+         :ok <- validate_castling_path_clear(game, side),
+         :ok <- validate_castling_safe(game, side) do
+      {:ok, Move.make(game, source, destination, castling_flag(side))}
     end
   end
 
@@ -61,6 +74,102 @@ defmodule Chess.BitBoards.Pieces.King do
     end
   end
 
+  defp castling_side(color, source, destination) do
+    case {source, destination, king_home(color)} do
+      {home, to, home} ->
+        case {to, kingside_destination(color), queenside_destination(color)} do
+          {kingside, kingside, _} -> {:ok, :kingside}
+          {queenside, _, queenside} -> {:ok, :queenside}
+          _ -> {:error, :cannot_castle}
+        end
+
+      _ ->
+        {:error, :cannot_castle}
+    end
+  end
+
+  defp validate_castling_rights(game, side) do
+    color = game.current_player
+    rook_square = rook_home(color, side)
+
+    cond do
+      piece_has_moved?(game.move_list, king_home(color)) ->
+        {:error, :cannot_castle}
+
+      piece_has_moved?(game.move_list, rook_square) ->
+        {:error, :cannot_castle}
+
+      not rook_on_square?(game.board, color, rook_square) ->
+        {:error, :cannot_castle}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp rook_on_square?(board, color, square) do
+    board
+    |> BitBoard.get({color, :rooks})
+    |> BitBoard.square_occupied?(square)
+  end
+
+  defp validate_castling_path_clear(game, side) do
+    occupied = BitBoard.get(game.board, :full)
+
+    if Enum.any?(
+         path_squares(game.current_player, side),
+         &BitBoard.square_occupied?(occupied, &1)
+       ) do
+      {:error, :cannot_castle}
+    else
+      :ok
+    end
+  end
+
+  defp validate_castling_safe(game, side) do
+    opponent = Game.opponent(game)
+    squares = transit_squares(game.current_player, side)
+
+    if Enum.any?(squares, &Attacks.square_attacked_by?(game.board, opponent, &1)) do
+      {:error, :cannot_castle}
+    else
+      :ok
+    end
+  end
+
+  defp castling_flag(:kingside), do: :king_castle
+  defp castling_flag(:queenside), do: :queen_castle
+
+  defp king_home(:white), do: {"e", 1}
+  defp king_home(:black), do: {"e", 8}
+
+  defp kingside_destination(:white), do: {"g", 1}
+  defp kingside_destination(:black), do: {"g", 8}
+
+  defp queenside_destination(:white), do: {"c", 1}
+  defp queenside_destination(:black), do: {"c", 8}
+
+  defp rook_home(:white, :kingside), do: {"h", 1}
+  defp rook_home(:white, :queenside), do: {"a", 1}
+  defp rook_home(:black, :kingside), do: {"h", 8}
+  defp rook_home(:black, :queenside), do: {"a", 8}
+
+  # Squares that must be empty between king and rook (includes destination).
+  defp path_squares(:white, :kingside), do: [{"f", 1}, {"g", 1}]
+  defp path_squares(:white, :queenside), do: [{"b", 1}, {"c", 1}, {"d", 1}]
+  defp path_squares(:black, :kingside), do: [{"f", 8}, {"g", 8}]
+  defp path_squares(:black, :queenside), do: [{"b", 8}, {"c", 8}, {"d", 8}]
+
+  # King start, pass-through, and landing squares — none may be attacked.
+  defp transit_squares(:white, :kingside), do: [{"e", 1}, {"f", 1}, {"g", 1}]
+  defp transit_squares(:white, :queenside), do: [{"e", 1}, {"d", 1}, {"c", 1}]
+  defp transit_squares(:black, :kingside), do: [{"e", 8}, {"f", 8}, {"g", 8}]
+  defp transit_squares(:black, :queenside), do: [{"e", 8}, {"d", 8}, {"c", 8}]
+
+  defp piece_has_moved?(move_list, square) do
+    Enum.any?(move_list, fn %Move{from: from} -> from == square end)
+  end
+
   defp king_square(board, color) do
     board
     |> BitBoard.get_raw({color, :king})
@@ -78,5 +187,9 @@ defmodule Chess.BitBoards.Pieces.King do
     rank_delta = abs(to_rank - from_rank)
 
     file_delta <= 1 and rank_delta <= 1 and {file_delta, rank_delta} != {0, 0}
+  end
+
+  defp castling_geometry?({<<from_file>>, from_rank}, {<<to_file>>, to_rank}) do
+    from_rank == to_rank and abs(to_file - from_file) == 2
   end
 end

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -3,13 +3,17 @@ defmodule Chess.BitBoards.Pieces.King do
   King move validation (`Chess.Moves.Validator`).
 
   Orchestrates geometry, self-capture, king-safety, and castling checks.
-  Attack detection lives in `Chess.Bitboards.Attacks`; candidate-move
-  simulation lives on `Chess.Boards.BitBoard`.
+  Castling geometry lives in `Chess.Bitboards.Castling`; attack detection
+  lives in `Chess.Bitboards.Attacks`; candidate-move simulation lives on
+  `Chess.Boards.BitBoard`.
   """
 
   @behaviour Chess.Moves.Validator
 
+  import Bitwise
+
   alias Chess.Bitboards.Attacks
+  alias Chess.Bitboards.Castling
   alias Chess.Bitboards.Move
   alias Chess.Boards.BitBoard
   alias Chess.Boards.Bitboards.Square
@@ -55,11 +59,11 @@ defmodule Chess.BitBoards.Pieces.King do
   end
 
   defp validate_typed_move(:castle, game, source, destination) do
-    with {:ok, side} <- castling_side(game.current_player, source, destination),
+    with {:ok, side} <- Castling.side(game.current_player, source, destination),
          :ok <- validate_castling_rights(game, side),
          :ok <- validate_castling_path_clear(game, side),
          :ok <- validate_castling_safe(game, side) do
-      {:ok, Move.make(game, source, destination, castling_flag(side))}
+      {:ok, Move.make(game, source, destination, Castling.flag(side))}
     end
   end
 
@@ -79,23 +83,11 @@ defmodule Chess.BitBoards.Pieces.King do
     end
   end
 
-  defp castling_side(color, source, destination) do
-    home = king_home(color)
-    kingside = kingside_destination(color)
-    queenside = queenside_destination(color)
-
-    case {source, destination} do
-      {^home, ^kingside} -> {:ok, :kingside}
-      {^home, ^queenside} -> {:ok, :queenside}
-      _ -> {:error, :cannot_castle}
-    end
-  end
-
   defp validate_castling_rights(game, side) do
     color = game.current_player
-    rook_square = rook_home(color, side)
+    rook_square = Castling.rook_home(color, side)
 
-    with :ok <- require_unmoved(game.move_list, king_home(color)),
+    with :ok <- require_unmoved(game.move_list, Castling.king_home(color)),
          :ok <- require_unmoved(game.move_list, rook_square) do
       require_rook_present(game.board, color, rook_square)
     end
@@ -110,35 +102,28 @@ defmodule Chess.BitBoards.Pieces.King do
   end
 
   defp require_rook_present(board, color, square) do
-    if rook_on_square?(board, color, square) do
+    rooks = BitBoard.get_raw(board, {color, :rooks})
+
+    if (rooks &&& Square.bitboard(square)) != 0 do
       :ok
     else
       {:error, :cannot_castle}
     end
   end
 
-  defp rook_on_square?(board, color, square) do
-    board
-    |> BitBoard.get({color, :rooks})
-    |> BitBoard.square_occupied?(square)
-  end
-
   defp validate_castling_path_clear(game, side) do
-    occupied = BitBoard.get(game.board, :full)
+    occupied = BitBoard.get_raw(game.board, :full)
 
-    if Enum.any?(
-         path_squares(game.current_player, side),
-         &BitBoard.square_occupied?(occupied, &1)
-       ) do
-      {:error, :cannot_castle}
-    else
+    if Castling.path_clear?(occupied, game.current_player, side) do
       :ok
+    else
+      {:error, :cannot_castle}
     end
   end
 
   defp validate_castling_safe(game, side) do
     opponent = Game.opponent(game)
-    squares = transit_squares(game.current_player, side)
+    squares = Castling.transit_squares(game.current_player, side)
 
     if Enum.any?(squares, &Attacks.square_attacked_by?(game.board, opponent, &1)) do
       {:error, :cannot_castle}
@@ -146,35 +131,6 @@ defmodule Chess.BitBoards.Pieces.King do
       :ok
     end
   end
-
-  defp castling_flag(:kingside), do: :king_castle
-  defp castling_flag(:queenside), do: :queen_castle
-
-  defp king_home(:white), do: {"e", 1}
-  defp king_home(:black), do: {"e", 8}
-
-  defp kingside_destination(:white), do: {"g", 1}
-  defp kingside_destination(:black), do: {"g", 8}
-
-  defp queenside_destination(:white), do: {"c", 1}
-  defp queenside_destination(:black), do: {"c", 8}
-
-  defp rook_home(:white, :kingside), do: {"h", 1}
-  defp rook_home(:white, :queenside), do: {"a", 1}
-  defp rook_home(:black, :kingside), do: {"h", 8}
-  defp rook_home(:black, :queenside), do: {"a", 8}
-
-  # Squares that must be empty between king and rook (includes destination).
-  defp path_squares(:white, :kingside), do: [{"f", 1}, {"g", 1}]
-  defp path_squares(:white, :queenside), do: [{"b", 1}, {"c", 1}, {"d", 1}]
-  defp path_squares(:black, :kingside), do: [{"f", 8}, {"g", 8}]
-  defp path_squares(:black, :queenside), do: [{"b", 8}, {"c", 8}, {"d", 8}]
-
-  # King start, pass-through, and landing squares — none may be attacked.
-  defp transit_squares(:white, :kingside), do: [{"e", 1}, {"f", 1}, {"g", 1}]
-  defp transit_squares(:white, :queenside), do: [{"e", 1}, {"d", 1}, {"c", 1}]
-  defp transit_squares(:black, :kingside), do: [{"e", 8}, {"f", 8}, {"g", 8}]
-  defp transit_squares(:black, :queenside), do: [{"e", 8}, {"d", 8}, {"c", 8}]
 
   defp piece_has_moved?(move_list, square) do
     Enum.any?(move_list, fn %Move{from: from} -> from == square end)

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -19,15 +19,8 @@ defmodule Chess.BitBoards.Pieces.King do
   @impl Chess.Moves.Validator
   @spec validate_move(Game.t(), Proposals.t()) :: {:ok, Move.t()} | {:error, atom()}
   def validate_move(game, %Proposals{source: source, destination: destination}) do
-    cond do
-      king_step?(source, destination) ->
-        validate_king_step(game, source, destination)
-
-      castling_geometry?(source, destination) ->
-        validate_castling(game, source, destination)
-
-      true ->
-        {:error, :invalid_geometry}
+    with {:ok, move_type} <- classify_geometry(source, destination) do
+      validate_typed_move(move_type, game, source, destination)
     end
   end
 
@@ -42,14 +35,26 @@ defmodule Chess.BitBoards.Pieces.King do
     end
   end
 
-  defp validate_king_step(game, source, destination) do
+  defp classify_geometry({<<from_file>>, from_rank}, {<<to_file>>, to_rank}) do
+    file_delta = abs(to_file - from_file)
+    rank_delta = abs(to_rank - from_rank)
+
+    case {file_delta, rank_delta} do
+      {0, 0} -> {:error, :invalid_geometry}
+      {file, rank} when file <= 1 and rank <= 1 -> {:ok, :step}
+      {2, 0} -> {:ok, :castle}
+      _ -> {:error, :invalid_geometry}
+    end
+  end
+
+  defp validate_typed_move(:step, game, source, destination) do
     with :ok <- validate_not_self_capture(game, destination),
          :ok <- validate_king_safety(game, source, destination) do
       {:ok, Move.make(game, source, destination)}
     end
   end
 
-  defp validate_castling(game, source, destination) do
+  defp validate_typed_move(:castle, game, source, destination) do
     with {:ok, side} <- castling_side(game.current_player, source, destination),
          :ok <- validate_castling_rights(game, side),
          :ok <- validate_castling_path_clear(game, side),
@@ -75,16 +80,14 @@ defmodule Chess.BitBoards.Pieces.King do
   end
 
   defp castling_side(color, source, destination) do
-    case {source, destination, king_home(color)} do
-      {home, to, home} ->
-        case {to, kingside_destination(color), queenside_destination(color)} do
-          {kingside, kingside, _} -> {:ok, :kingside}
-          {queenside, _, queenside} -> {:ok, :queenside}
-          _ -> {:error, :cannot_castle}
-        end
+    home = king_home(color)
+    kingside = kingside_destination(color)
+    queenside = queenside_destination(color)
 
-      _ ->
-        {:error, :cannot_castle}
+    case {source, destination} do
+      {^home, ^kingside} -> {:ok, :kingside}
+      {^home, ^queenside} -> {:ok, :queenside}
+      _ -> {:error, :cannot_castle}
     end
   end
 
@@ -92,18 +95,25 @@ defmodule Chess.BitBoards.Pieces.King do
     color = game.current_player
     rook_square = rook_home(color, side)
 
-    cond do
-      piece_has_moved?(game.move_list, king_home(color)) ->
-        {:error, :cannot_castle}
+    with :ok <- require_unmoved(game.move_list, king_home(color)),
+         :ok <- require_unmoved(game.move_list, rook_square) do
+      require_rook_present(game.board, color, rook_square)
+    end
+  end
 
-      piece_has_moved?(game.move_list, rook_square) ->
-        {:error, :cannot_castle}
+  defp require_unmoved(move_list, square) do
+    if piece_has_moved?(move_list, square) do
+      {:error, :cannot_castle}
+    else
+      :ok
+    end
+  end
 
-      not rook_on_square?(game.board, color, rook_square) ->
-        {:error, :cannot_castle}
-
-      true ->
-        :ok
+  defp require_rook_present(board, color, square) do
+    if rook_on_square?(board, color, square) do
+      :ok
+    else
+      {:error, :cannot_castle}
     end
   end
 
@@ -180,16 +190,5 @@ defmodule Chess.BitBoards.Pieces.King do
     board
     |> BitBoard.get(color)
     |> BitBoard.square_occupied?(square)
-  end
-
-  defp king_step?({<<from_file>>, from_rank}, {<<to_file>>, to_rank}) do
-    file_delta = abs(to_file - from_file)
-    rank_delta = abs(to_rank - from_rank)
-
-    file_delta <= 1 and rank_delta <= 1 and {file_delta, rank_delta} != {0, 0}
-  end
-
-  defp castling_geometry?({<<from_file>>, from_rank}, {<<to_file>>, to_rank}) do
-    from_rank == to_rank and abs(to_file - from_file) == 2
   end
 end

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -122,10 +122,9 @@ defmodule Chess.BitBoards.Pieces.King do
   end
 
   defp validate_castling_safe(game, side) do
-    opponent = Game.opponent(game)
-    squares = Castling.transit_squares(game.current_player, side)
+    mask = Castling.transit_mask(game.current_player, side)
 
-    if Enum.any?(squares, &Attacks.square_attacked_by?(game.board, opponent, &1)) do
+    if Attacks.mask_attacked_by?(game.board, Game.opponent(game), mask) do
       {:error, :cannot_castle}
     else
       :ok

--- a/test/chess/board/bitboards/attacks_test.exs
+++ b/test/chess/board/bitboards/attacks_test.exs
@@ -131,6 +131,34 @@ defmodule Chess.Bitboards.AttacksTest do
     end
   end
 
+  describe "mask_attacked_by?/3" do
+    test "returns true when any square in the mask is attacked" do
+      board = board_with([{{:black, :bishops}, {"a", 6}}])
+      mask = Square.bitboard({"e", 1}) ||| Square.bitboard({"f", 1}) ||| Square.bitboard({"g", 1})
+
+      assert Attacks.mask_attacked_by?(board, :black, mask)
+    end
+
+    test "returns false when the mask is clear of attacks" do
+      board = board_with([{{:black, :rooks}, {"a", 8}}])
+      mask = Square.bitboard({"e", 1}) ||| Square.bitboard({"f", 1}) ||| Square.bitboard({"g", 1})
+
+      refute Attacks.mask_attacked_by?(board, :black, mask)
+    end
+
+    test "agrees with square_attacked_by?/3 for a single-square mask" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:black, :rooks}, {"e", 8}}
+        ])
+
+      assert Attacks.mask_attacked_by?(board, :black, Square.bitboard({"e", 1}))
+      assert Attacks.square_attacked_by?(board, :black, {"e", 1})
+      refute Attacks.mask_attacked_by?(board, :black, Square.bitboard({"f", 1}))
+    end
+  end
+
   describe "king_attacks/1" do
     test "matches coordinate-delta attack sets for every square index" do
       for square_index <- 0..63 do

--- a/test/chess/board/bitboards/castling_test.exs
+++ b/test/chess/board/bitboards/castling_test.exs
@@ -39,6 +39,15 @@ defmodule Chess.Bitboards.CastlingTest do
     end
   end
 
+  describe "transit_mask/2" do
+    test "is the bitwise OR of king start, pass-through, and landing squares" do
+      expected =
+        Square.bitboard({"e", 1}) ||| Square.bitboard({"f", 1}) ||| Square.bitboard({"g", 1})
+
+      assert Castling.transit_mask(:white, :kingside) == expected
+    end
+  end
+
   describe "side/3" do
     test "classifies white kingside and queenside castling" do
       assert {:ok, :kingside} = Castling.side(:white, {"e", 1}, {"g", 1})

--- a/test/chess/board/bitboards/castling_test.exs
+++ b/test/chess/board/bitboards/castling_test.exs
@@ -1,0 +1,52 @@
+defmodule Chess.Bitboards.CastlingTest do
+  use ExUnit.Case, async: true
+
+  import Bitwise
+
+  alias Chess.Bitboards.Castling
+  alias Chess.Boards.Bitboards.Square
+
+  describe "path_clear?/3" do
+    test "returns true when the kingside path is empty" do
+      assert Castling.path_clear?(0, :white, :kingside)
+    end
+
+    test "returns false when any kingside path square is occupied" do
+      occupied = Square.bitboard({"f", 1})
+
+      refute Castling.path_clear?(occupied, :white, :kingside)
+    end
+
+    test "returns false when any queenside path square is occupied" do
+      occupied = Square.bitboard({"b", 1})
+
+      refute Castling.path_clear?(occupied, :white, :queenside)
+    end
+
+    test "ignores occupancy outside the castling path" do
+      occupied = Square.bitboard({"a", 2}) ||| Square.bitboard({"h", 8})
+
+      assert Castling.path_clear?(occupied, :white, :kingside)
+      assert Castling.path_clear?(occupied, :white, :queenside)
+    end
+  end
+
+  describe "path_mask/2" do
+    test "is the bitwise OR of each path square" do
+      expected = Square.bitboard({"f", 1}) ||| Square.bitboard({"g", 1})
+
+      assert Castling.path_mask(:white, :kingside) == expected
+    end
+  end
+
+  describe "side/3" do
+    test "classifies white kingside and queenside castling" do
+      assert {:ok, :kingside} = Castling.side(:white, {"e", 1}, {"g", 1})
+      assert {:ok, :queenside} = Castling.side(:white, {"e", 1}, {"c", 1})
+    end
+
+    test "rejects non-castling destinations from the king home square" do
+      assert {:error, :cannot_castle} = Castling.side(:white, {"e", 1}, {"e", 2})
+    end
+  end
+end

--- a/test/chess/board/bitboards/pieces/king_test.exs
+++ b/test/chess/board/bitboards/pieces/king_test.exs
@@ -203,6 +203,134 @@ defmodule Chess.BitBoards.Pieces.KingTest do
       assert {:error, :king_in_check} = King.validate_move(game, proposal)
     end
 
+    test "accepts kingside castling when rights and path are clear" do
+      # Board state: White king on e1 (unmoved), white rook on h1 (unmoved),
+      #              squares f1 and g1 empty, not attacked.
+      # Move: e1 -> g1
+      # Expected: {:ok, %Move{from: {"e", 1}, to: {"g", 1}, flag: :king_castle}}
+      #
+      #     a   b   c   d   e   f   g   h
+      #   +---+---+---+---+---+---+---+---+
+      # 8 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 7 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 6 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 5 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 4 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 3 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 2 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 1 |   |   |   |   | K |   | * | R |  <- king castles to g1
+      #   +---+---+---+---+---+---+---+---+
+      game =
+        game_with([
+          {{:white, :king}, {"e", 1}},
+          {{:white, :rooks}, {"h", 1}}
+        ])
+
+      proposal = %Proposals{source: {"e", 1}, destination: {"g", 1}}
+
+      assert {:ok, %Move{from: {"e", 1}, to: {"g", 1}, flag: :king_castle}} =
+               King.validate_move(game, proposal)
+    end
+
+    test "accepts queenside castling when rights and path are clear" do
+      # Board state: White king on e1 (unmoved), white rook on a1 (unmoved),
+      #              squares b1, c1, d1 empty, king doesn't pass through check.
+      # Move: e1 -> c1
+      # Expected: {:ok, %Move{from: {"e", 1}, to: {"c", 1}, flag: :queen_castle}}
+      #
+      #     a   b   c   d   e   f   g   h
+      #   +---+---+---+---+---+---+---+---+
+      # 8 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 7 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 6 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 5 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 4 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 3 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 2 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 1 | R |   | * |   | K |   |   |   |  <- king castles to c1
+      #   +---+---+---+---+---+---+---+---+
+      game =
+        game_with([
+          {{:white, :king}, {"e", 1}},
+          {{:white, :rooks}, {"a", 1}}
+        ])
+
+      proposal = %Proposals{source: {"e", 1}, destination: {"c", 1}}
+
+      assert {:ok, %Move{from: {"e", 1}, to: {"c", 1}, flag: :queen_castle}} =
+               King.validate_move(game, proposal)
+    end
+
+    test "rejects castling when the king has previously moved" do
+      # Board state: Same as kingside castling success, but move_list contains
+      #              a prior king move (king moved away and back to e1).
+      # Move: e1 -> g1
+      # Expected: {:error, :cannot_castle}
+      game =
+        game_with([
+          {{:white, :king}, {"e", 1}},
+          {{:white, :rooks}, {"h", 1}}
+        ])
+        |> Map.put(:move_list, [
+          %Move{from: {"e", 1}, to: {"e", 2}, flag: :quiet},
+          %Move{from: {"e", 2}, to: {"e", 1}, flag: :quiet}
+        ])
+
+      proposal = %Proposals{source: {"e", 1}, destination: {"g", 1}}
+
+      assert {:error, :cannot_castle} = King.validate_move(game, proposal)
+    end
+
+    test "rejects castling when the king would pass through an attacked square" do
+      # Board state: White king on e1, white rook on h1, black bishop on a6
+      #              (which attacks f1 diagonally, so king would pass through check).
+      # Move: e1 -> g1
+      # Expected: {:error, :cannot_castle}
+      #
+      #     a   b   c   d   e   f   g   h
+      #   +---+---+---+---+---+---+---+---+
+      # 8 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 7 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 6 | b |   |   |   |   |   |   |   |  <- black bishop attacks f1
+      #   +---+---+---+---+---+---+---+---+
+      # 5 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 4 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 3 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 2 |   |   |   |   |   |   |   |   |
+      #   +---+---+---+---+---+---+---+---+
+      # 1 |   |   |   |   | K | X |   | R |  <- f1 attacked, can't castle
+      #   +---+---+---+---+---+---+---+---+
+      game =
+        game_with([
+          {{:white, :king}, {"e", 1}},
+          {{:white, :rooks}, {"h", 1}},
+          {{:black, :bishops}, {"a", 6}}
+        ])
+
+      proposal = %Proposals{source: {"e", 1}, destination: {"g", 1}}
+
+      assert {:error, :cannot_castle} = King.validate_move(game, proposal)
+    end
+
     test "accepts a corner move to an adjacent diagonal square" do
       # Board state: White king on a1.
       # Move: a1 -> b2 (only 3 valid moves from a1: a2, b1, b2)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements kingside and queenside castling for `Chess.BitBoards.Pieces.King` per `plans/move_validation/KING_MOVE_VALIDATION_PLAN.md`.

## Changes

- `validate_move/2` classifies geometry (`:step` vs `:castle`) then validates via `with` pipelines
- Castling geometry (homes, destinations, path/transit masks) lives in `Chess.Bitboards.Castling`
- Clear-path checks AND occupancy with a path mask; transit safety ANDs opponent attacks (`Attacks.attacks_by/2`) with a transit mask — no square enumeration
- Returns `:king_castle` / `:queen_castle` on success, or `:cannot_castle` on failure
- Adds plan tests 7–10 (kingside/queenside success, king previously moved, pass-through attacked)

## CI fix

Setup was failing on a Docker Hub timeout while pulling `elixir:1.20.2-otp-29`. This PR now:

- Pre-pulls `elixir:1.20.2-otp-29` and `postgres:17.6` with retries before `devcontainers/ci`
- Fixes `hashFiles('**/mix.lock')` quoting so the mix dependency cache key is not empty

## Testing

- `mix test` for king/castling/attacks — 42 passed
- `mix format --check-formatted` and `mix credo --strict` on changed files — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbcc8-1528-709f-918e-18527634267e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbcc8-1528-709f-918e-18527634267e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

