### PR TITLE
Add square index and mask APIs for bitboard hot paths

### DIFF
--- a/lib/chess/board/bitboard.ex
+++ b/lib/chess/board/bitboard.ex
@@ -143,12 +143,33 @@ defmodule Chess.Boards.BitBoard do
   order of ranks in the binary goes from 8 to 1, so we need
   to reverse the ranks. Same with the files (columns) within
   each part of the binary, going from h to a.
+
+  For engine hot paths, prefer `occupied?/2` with a square mask from
+  `Chess.Boards.Bitboards.Square.mask/1` or `mask_from_index/1` so the
+  coordinate need not be re-parsed on every check.
   """
   @spec square_occupied?(bitboard(), Coordinates.t()) :: boolean()
   def square_occupied?(bitboard, {file, rank}) do
     <<rank_byte::integer-size(8)>> = :binary.part(bitboard, {8 - rank, 1})
     mask = 1 <<< Coordinates.file_bit_index(file)
     (rank_byte &&& mask) != 0
+  end
+
+  @doc """
+  Returns true if any bit set in `square_mask` is also set in the bitboard.
+
+  Accepts either a 64-bit bitboard binary or a raw integer bitboard. This is
+  the preferred occupancy check on move/attack hot paths — pass a mask from
+  `Chess.Boards.Bitboards.Square.mask/1` or `mask_from_index/1` (convert a
+  square index with the latter) rather than a `{file, rank}` tuple.
+  """
+  @spec occupied?(bitboard() | integer(), integer()) :: boolean()
+  def occupied?(<<raw::integer-size(64)>>, square_mask) when is_integer(square_mask) do
+    occupied?(raw, square_mask)
+  end
+
+  def occupied?(raw, square_mask) when is_integer(raw) and is_integer(square_mask) do
+    (raw &&& square_mask) != 0
   end
 
   @doc """

--- a/lib/chess/board/bitboards/square.ex
+++ b/lib/chess/board/bitboards/square.ex
@@ -2,6 +2,20 @@ defmodule Chess.Boards.Bitboards.Square do
   @moduledoc """
   Conveniences for working with bitboard representations of
   squares on the Chess board.
+
+  ## Representations
+
+  Squares appear in two complementary forms:
+
+  * **Coordinate tuples** (`t:t/0`, e.g. `{"e", 1}`) — human-legible. Prefer
+    these in tests, documentation examples, and at the user-input boundary
+    (`Chess.Moves.Proposals`). Convert once at the edge of engine work.
+  * **Square indices** (`t:index/0`, `0..63`) and **single-bit masks**
+    (`t:mask/0`, `1 <<< index`) — the forms used on move/attack hot paths.
+    Bit 0 is h1, bit 7 is a1, bit 8 is h2, …, bit 63 is a8.
+
+  Use `to_index/1` / `from_index/1` and `mask/1` / `mask_from_index/1` to
+  convert; avoid re-deriving masks from tuples inside loops or validators.
   """
   import Bitwise
 
@@ -9,6 +23,19 @@ defmodule Chess.Boards.Bitboards.Square do
   alias Chess.Board.Coordinates
 
   @type t() :: Coordinates.t()
+
+  @typedoc """
+  Zero-based square index into a 64-bit bitboard. Bit 0 is h1; bit 63 is a8.
+  """
+  @type index() :: 0..63
+
+  @typedoc """
+  A 64-bit integer with (typically) a single bit set, identifying one square.
+  """
+  @type mask() :: integer()
+
+  # File letters ordered by bit index within a rank (bit 0 = h, bit 7 = a).
+  @files List.to_tuple(~w(h g f e d c b a))
 
   @doc """
   Attempts to apply a file and rank delta to a square.
@@ -28,17 +55,48 @@ defmodule Chess.Boards.Bitboards.Square do
   end
 
   @doc """
-  Returns the 64-bit bitboard representation of the square;
-  that is, a 64-bit binary with a single bit set at the index
-  representing the square.
-  """
-  @spec bitboard(t()) :: integer()
-  def bitboard({file, rank}) do
-    file_index = Coordinates.file_bit_index(file)
-    rank_offset = (rank - 1) * 8
+  Converts a `{file, rank}` coordinate to a square index (`0..63`).
 
-    1 <<< (rank_offset + file_index)
+  Prefer calling this once at an API boundary, then using the index or a
+  `mask_from_index/1` result on the hot path.
+  """
+  @spec to_index(t()) :: index()
+  def to_index({file, rank}) do
+    Coordinates.file_bit_index(file) + (rank - 1) * 8
   end
+
+  @doc """
+  Converts a square index (`0..63`) back to a `{file, rank}` coordinate.
+  """
+  @spec from_index(index()) :: t()
+  def from_index(index) when index in 0..63 do
+    {elem(@files, rem(index, 8)), div(index, 8) + 1}
+  end
+
+  @doc """
+  Returns the single-bit mask for a square index (`1 <<< index`).
+  """
+  @spec mask_from_index(index()) :: mask()
+  def mask_from_index(index) when index in 0..63, do: 1 <<< index
+
+  @doc """
+  Returns the single-bit mask for a `{file, rank}` coordinate.
+
+  Equivalent to `bitboard/1`; prefer this name on new hot-path call sites.
+  For repeated use, convert with `to_index/1` once and call `mask_from_index/1`.
+  """
+  @spec mask(t()) :: mask()
+  def mask(square), do: mask_from_index(to_index(square))
+
+  @doc """
+  Returns the 64-bit bitboard representation of the square;
+  that is, a 64-bit integer with a single bit set at the index
+  representing the square.
+
+  See also `mask/1` (alias) and `mask_from_index/1`.
+  """
+  @spec bitboard(t()) :: mask()
+  def bitboard(square), do: mask(square)
 
   @doc """
   Converts a single-bit bitboard integer to a square coordinate.
@@ -50,10 +108,7 @@ defmodule Chess.Boards.Bitboards.Square do
   def from_bitboard(0), do: nil
 
   def from_bitboard(bits) when is_integer(bits) and bits > 0 do
-    bit_index = trailing_zeros(bits)
-    rank = div(bit_index, 8) + 1
-    file = Enum.at(~w(h g f e d c b a), rem(bit_index, 8))
-    {file, rank}
+    from_index(trailing_zeros(bits))
   end
 
   defp trailing_zeros(n), do: trailing_zeros(n, 0)

--- a/test/chess/board/bitboard_test.exs
+++ b/test/chess/board/bitboard_test.exs
@@ -347,6 +347,44 @@ defmodule Chess.Boards.BitBoardTest do
     end
   end
 
+  describe "occupied?/2" do
+    test "returns true when the mask intersects a bitboard binary" do
+      black_pawns = BitBoard.get(BitBoard.new(), {Color.black(), :pawns})
+      assert BitBoard.occupied?(black_pawns, Square.mask({"a", 7}))
+    end
+
+    test "returns false when the mask does not intersect a bitboard binary" do
+      white_pawns = BitBoard.get(BitBoard.new(), {Color.white(), :pawns})
+      refute BitBoard.occupied?(white_pawns, Square.mask({"a", 7}))
+    end
+
+    test "accepts a raw integer bitboard and a mask from an index" do
+      raw = BitBoard.get_raw(BitBoard.new(), {:black, :pawns})
+      index = Square.to_index({"a", 7})
+
+      assert BitBoard.occupied?(raw, Square.mask_from_index(index))
+      refute BitBoard.occupied?(raw, Square.mask_from_index(Square.to_index({"a", 2})))
+    end
+
+    test "agrees with square_occupied?/2 for starting positions" do
+      board = BitBoard.new()
+
+      for color <- [Color.white(), Color.black()],
+          piece <- [:pawns, :rooks, :knights, :bishops, :queens, :king] do
+        bitboard = BitBoard.get(board, {color, piece})
+        raw = BitBoard.get_raw(board, {color, piece})
+
+        for rank <- 1..8, file <- ?a..?h do
+          square = {<<file>>, rank}
+          mask = Square.mask(square)
+
+          assert BitBoard.occupied?(bitboard, mask) == BitBoard.square_occupied?(bitboard, square)
+          assert BitBoard.occupied?(raw, mask) == BitBoard.square_occupied?(bitboard, square)
+        end
+      end
+    end
+  end
+
   describe "empty/0" do
     test "returns an empty bitboard" do
       assert <<0, 0, 0, 0, 0, 0, 0, 0>> == BitBoard.empty()

--- a/test/chess/board/bitboards/square_test.exs
+++ b/test/chess/board/bitboards/square_test.exs
@@ -39,6 +39,48 @@ defmodule Chess.Boards.Bitboards.SquareTest do
     end
   end
 
+  describe "to_index/1 and from_index/1" do
+    squares =
+      for rank <- 1..8, file <- ?h..?a//-1 do
+        {<<file>>, rank}
+      end
+
+    for {square, index} <- Enum.with_index(squares) do
+      test "round-trips #{inspect(square)} through index #{index}" do
+        assert Square.to_index(unquote(square)) == unquote(index)
+        assert Square.from_index(unquote(index)) == unquote(square)
+        assert Square.from_index(Square.to_index(unquote(square))) == unquote(square)
+      end
+    end
+
+    test "maps corner and center squares to known indices" do
+      assert Square.to_index({"h", 1}) == 0
+      assert Square.to_index({"a", 1}) == 7
+      assert Square.to_index({"h", 8}) == 56
+      assert Square.to_index({"a", 8}) == 63
+      assert Square.to_index({"e", 1}) == 3
+      assert Square.to_index({"e", 4}) == 27
+    end
+  end
+
+  describe "mask_from_index/1 and mask/1" do
+    squares =
+      for rank <- 1..8, file <- ?h..?a//-1 do
+        {<<file>>, rank}
+      end
+
+    for {square, index} <- Enum.with_index(squares) do
+      test "mask_from_index/1 sets only bit #{index} for #{inspect(square)}" do
+        assert Square.mask_from_index(unquote(index)) == 1 <<< unquote(index)
+      end
+
+      test "mask/1 matches mask_from_index/1 for #{inspect(square)}" do
+        assert Square.mask(unquote(square)) == Square.mask_from_index(unquote(index))
+        assert Square.mask(unquote(square)) == Square.bitboard(unquote(square))
+      end
+    end
+  end
+
   describe "bitboard/1" do
     squares =
       for rank <- 1..8, file <- ?h..?a//-1 do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 1** of #66 / #67: foundation APIs so engine code can work with square indices and single-bit masks instead of repeatedly converting `{file, rank}` tuples.

### Changes

- **`Chess.Boards.Bitboards.Square`**
  - Document coordinate tuples (human/tests/I/O) vs indices/`mask`s (hot path)
  - `to_index/1` / `from_index/1` — tuple ↔ `0..63` (bit 0 = h1)
  - `mask/1` — alias of `bitboard/1` for clearer hot-path naming
  - `mask_from_index/1` — `1 <<< index`
  - `bitboard/1` / `from_bitboard/1` now route through index helpers
- **`Chess.Boards.BitBoard.occupied?/2`**
  - Mask-based occupancy on binary or raw integer bitboards: `(raw &&& mask) != 0`
  - Prefer over `square_occupied?/2` on hot paths; convert indices via `Square.mask_from_index/1`

### Tests

Round-trip coverage for index/mask helpers; `occupied?/2` agreement with `square_occupied?/2` across starting piece boards.

### Non-goals (later phases)

No call-site migration of Attacks/King/Castling/Move yet — that is Phases 2–4 in #67.

Refs: #66, #67

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc1f5-5ba0-7e8e-a012-7cbc8210b95a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc1f5-5ba0-7e8e-a012-7cbc8210b95a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

