### PR TITLE
Migrate attack/simulation hot paths to square masks (Phase 2)

### DIFF
--- a/lib/chess/board/bitboards/attacks.ex
+++ b/lib/chess/board/bitboards/attacks.ex
@@ -67,17 +67,21 @@ defmodule Chess.Bitboards.Attacks do
                   |> List.to_tuple()
 
   @doc """
-  Returns true if any piece of `attacker` color attacks `square`.
+  Returns true if any piece of `attacker` color attacks the square identified
+  by `square_mask`.
+
+  `square_mask` is a single-bit integer mask (`Square.mask/1` /
+  `Square.mask_from_index/1`). Callers should convert from `{file, rank}`
+  once at the API boundary — this function does not accept tuples.
   """
-  @spec square_attacked_by?(BitBoard.t(), Chess.player(), Square.t()) :: boolean()
-  def square_attacked_by?(board, attacker, square) do
-    target = Square.bitboard(square)
+  @spec square_attacked_by?(BitBoard.t(), Chess.player(), Square.mask()) :: boolean()
+  def square_attacked_by?(board, attacker, square_mask) when is_integer(square_mask) do
     occupied = BitBoard.get_raw(board, :full)
 
-    attacked_by_king?(board, attacker, target) or
-      attacked_by_knight?(board, attacker, target) or
-      attacked_by_pawn?(board, attacker, target) or
-      attacked_by_slider?(board, attacker, target, occupied)
+    attacked_by_king?(board, attacker, square_mask) or
+      attacked_by_knight?(board, attacker, square_mask) or
+      attacked_by_pawn?(board, attacker, square_mask) or
+      attacked_by_slider?(board, attacker, square_mask, occupied)
   end
 
   @doc """

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -30,12 +30,15 @@ defmodule Chess.BitBoards.Pieces.King do
 
   @doc """
   Returns true if the side to move's king is under attack in `game`.
+
+  Passes the king's bitboard mask straight to attack detection — no
+  tuple round-trip via `Square.from_bitboard/1`.
   """
   @spec in_check?(Game.t()) :: boolean()
   def in_check?(%Game{} = game) do
-    case king_square(game.board, game.current_player) do
-      nil -> false
-      square -> Attacks.square_attacked_by?(game.board, Game.opponent(game), square)
+    case BitBoard.get_raw(game.board, {game.current_player, :king}) do
+      0 -> false
+      king_mask -> Attacks.square_attacked_by?(game.board, Game.opponent(game), king_mask)
     end
   end
 
@@ -76,7 +79,10 @@ defmodule Chess.BitBoards.Pieces.King do
   end
 
   defp validate_king_safety(game, source, destination) do
-    if game |> Game.apply_candidate_move(:king, source, destination) |> in_check?() do
+    from_mask = Square.mask(source)
+    to_mask = Square.mask(destination)
+
+    if game |> Game.apply_candidate_move(:king, from_mask, to_mask) |> in_check?() do
       {:error, :king_in_check}
     else
       :ok
@@ -133,12 +139,6 @@ defmodule Chess.BitBoards.Pieces.King do
 
   defp piece_has_moved?(move_list, square) do
     Enum.any?(move_list, fn %Move{from: from} -> from == square end)
-  end
-
-  defp king_square(board, color) do
-    board
-    |> BitBoard.get_raw({color, :king})
-    |> Square.from_bitboard()
   end
 
   defp occupied_by?(board, color, square) do

--- a/lib/chess/game.ex
+++ b/lib/chess/game.ex
@@ -34,20 +34,22 @@ defmodule Chess.Game do
   Applies a candidate move for validation / king-safety simulation.
 
   Clears any opponent piece on the destination square, then moves the given
-  piece for the side to move from `from` to `to`. Returns a game with the
-  updated board only — move list, side to move, castling rights, en passant,
-  etc. are left unchanged.
+  piece for the side to move from `from_mask` to `to_mask`. Both arguments
+  are single-bit integer masks (`Square.mask/1` / `Square.mask_from_index/1`).
+  Convert from `{file, rank}` once at the caller (e.g. validator entry), not
+  inside simulation loops.
+
+  Returns a game with the updated board only — move list, side to move,
+  castling rights, en passant, etc. are left unchanged.
   """
-  @spec apply_candidate_move(t(), atom(), Square.t(), Square.t()) :: t()
+  @spec apply_candidate_move(t(), atom(), Square.mask(), Square.mask()) :: t()
   def apply_candidate_move(
         %__MODULE__{board: board, current_player: color} = game,
         piece_type,
-        from,
-        to
-      ) do
-    from_mask = Square.bitboard(from)
-    to_mask = Square.bitboard(to)
-
+        from_mask,
+        to_mask
+      )
+      when is_integer(from_mask) and is_integer(to_mask) do
     updated_board =
       board
       |> BitBoard.clear_square(opponent(game), to_mask)

--- a/lib/chess/pieces.ex
+++ b/lib/chess/pieces.ex
@@ -5,6 +5,7 @@ defmodule Chess.Pieces do
   """
   alias Chess.Board.Coordinates
   alias Chess.Boards.BitBoard
+  alias Chess.Boards.Bitboards.Square
   alias Chess.BitBoards.Pieces.{Bishop, King, Knight, Pawn, Queen, Rook}
   alias Chess.Game
 
@@ -14,18 +15,25 @@ defmodule Chess.Pieces do
   @type piece() :: Bishop | King | Knight | Pawn | Queen | Rook
 
   @doc """
-  Takes in a game and a source position (given as a `{file, rank}` tuple)
-  and returns the piece module for the piece that is present at the given
-  source position.
+  Classifies the piece of the side to move occupying `source`.
 
-  If the source position is not occupied, returns an error tuple instead.
+  `source` may be a single-bit square mask (`Square.mask/1`) or a
+  `{file, rank}` coordinate. Tuples are converted once at this boundary;
+  classification itself uses mask intersection against each piece bitboard.
+
+  Returns `{:ok, piece_module}` when occupied, or `{:error, :unoccupied}`.
   """
-  @spec classify(Game.t(), Coordinates.t()) :: {:ok, piece()} | {:error, :unoccupied}
-  def classify(%Game{} = game, source_coordinates) do
+  @spec classify(Game.t(), Square.mask() | Coordinates.t()) ::
+          {:ok, piece()} | {:error, :unoccupied}
+  def classify(%Game{} = game, {file, rank}) when is_binary(file) and is_integer(rank) do
+    classify(game, Square.mask({file, rank}))
+  end
+
+  def classify(%Game{} = game, source_mask) when is_integer(source_mask) do
     bitboards = BitBoard.get_boards_by_color(game.board, game.current_player)
 
     Enum.reduce_while(bitboards, {:error, :unoccupied}, fn {piece, bitboard}, _result ->
-      if BitBoard.square_occupied?(bitboard, source_coordinates) do
+      if BitBoard.occupied?(bitboard, source_mask) do
         {:halt, {:ok, modularize(piece)}}
       else
         {:cont, {:error, :unoccupied}}

--- a/lib/chess/pieces.ex
+++ b/lib/chess/pieces.ex
@@ -3,10 +3,10 @@ defmodule Chess.Pieces do
   Functions and types for defining and working with
   the different type of chess pieces.
   """
+  alias Chess.BitBoards.Pieces.{Bishop, King, Knight, Pawn, Queen, Rook}
   alias Chess.Board.Coordinates
   alias Chess.Boards.BitBoard
   alias Chess.Boards.Bitboards.Square
-  alias Chess.BitBoards.Pieces.{Bishop, King, Knight, Pawn, Queen, Rook}
   alias Chess.Game
 
   @typedoc """

--- a/test/chess/board/bitboards/attacks_test.exs
+++ b/test/chess/board/bitboards/attacks_test.exs
@@ -37,7 +37,7 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:black, :king}, {"e", 5}}
         ])
 
-      assert Attacks.square_attacked_by?(board, :black, {"e", 4})
+      assert Attacks.square_attacked_by?(board, :black, Square.mask({"e", 4}))
     end
 
     test "detects knight attacks without wraparound from the a-file" do
@@ -47,7 +47,7 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:black, :knights}, {"b", 6}}
         ])
 
-      assert Attacks.square_attacked_by?(board, :black, {"a", 4})
+      assert Attacks.square_attacked_by?(board, :black, Square.mask({"a", 4}))
 
       # Knight on h5 must not wrap and appear to attack a4.
       wrapped =
@@ -56,7 +56,7 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:black, :knights}, {"h", 5}}
         ])
 
-      refute Attacks.square_attacked_by?(wrapped, :black, {"a", 4})
+      refute Attacks.square_attacked_by?(wrapped, :black, Square.mask({"a", 4}))
     end
 
     test "detects black pawn attacks and ignores the wrong direction" do
@@ -66,7 +66,7 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:black, :pawns}, {"d", 5}}
         ])
 
-      assert Attacks.square_attacked_by?(attacked, :black, {"e", 4})
+      assert Attacks.square_attacked_by?(attacked, :black, Square.mask({"e", 4}))
 
       behind =
         board_with([
@@ -74,7 +74,7 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:black, :pawns}, {"d", 3}}
         ])
 
-      refute Attacks.square_attacked_by?(behind, :black, {"e", 4})
+      refute Attacks.square_attacked_by?(behind, :black, Square.mask({"e", 4}))
     end
 
     test "detects white pawn reverse attacks" do
@@ -84,7 +84,7 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:white, :pawns}, {"d", 4}}
         ])
 
-      assert Attacks.square_attacked_by?(board, :white, {"e", 5})
+      assert Attacks.square_attacked_by?(board, :white, Square.mask({"e", 5}))
     end
 
     test "detects rook attacks and stops at the first blocker" do
@@ -94,7 +94,7 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:black, :rooks}, {"e", 8}}
         ])
 
-      assert Attacks.square_attacked_by?(open_file, :black, {"e", 1})
+      assert Attacks.square_attacked_by?(open_file, :black, Square.mask({"e", 1}))
 
       blocked =
         board_with([
@@ -103,7 +103,7 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:black, :rooks}, {"e", 8}}
         ])
 
-      refute Attacks.square_attacked_by?(blocked, :black, {"e", 1})
+      refute Attacks.square_attacked_by?(blocked, :black, Square.mask({"e", 1}))
     end
 
     test "detects bishop and queen diagonal attacks" do
@@ -113,7 +113,7 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:black, :bishops}, {"b", 4}}
         ])
 
-      assert Attacks.square_attacked_by?(bishop, :black, {"e", 1})
+      assert Attacks.square_attacked_by?(bishop, :black, Square.mask({"e", 1}))
 
       queen =
         board_with([
@@ -121,13 +121,24 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:black, :queens}, {"e", 8}}
         ])
 
-      assert Attacks.square_attacked_by?(queen, :black, {"e", 4})
+      assert Attacks.square_attacked_by?(queen, :black, Square.mask({"e", 4}))
     end
 
     test "returns false when no attacker hits the square" do
       board = board_with([{{:white, :king}, {"e", 1}}])
 
-      refute Attacks.square_attacked_by?(board, :black, {"e", 1})
+      refute Attacks.square_attacked_by?(board, :black, Square.mask({"e", 1}))
+    end
+
+    test "accepts a mask built from a square index" do
+      board =
+        board_with([
+          {{:white, :king}, {"e", 1}},
+          {{:black, :rooks}, {"e", 8}}
+        ])
+
+      mask = Square.mask_from_index(Square.to_index({"e", 1}))
+      assert Attacks.square_attacked_by?(board, :black, mask)
     end
   end
 
@@ -153,9 +164,9 @@ defmodule Chess.Bitboards.AttacksTest do
           {{:black, :rooks}, {"e", 8}}
         ])
 
-      assert Attacks.mask_attacked_by?(board, :black, Square.bitboard({"e", 1}))
-      assert Attacks.square_attacked_by?(board, :black, {"e", 1})
-      refute Attacks.mask_attacked_by?(board, :black, Square.bitboard({"f", 1}))
+      assert Attacks.mask_attacked_by?(board, :black, Square.mask({"e", 1}))
+      assert Attacks.square_attacked_by?(board, :black, Square.mask({"e", 1}))
+      refute Attacks.mask_attacked_by?(board, :black, Square.mask({"f", 1}))
     end
   end
 

--- a/test/chess/game_test.exs
+++ b/test/chess/game_test.exs
@@ -27,9 +27,10 @@ defmodule Chess.GameTest do
     test "moves a piece onto an empty square" do
       game = game_with([{{:white, :king}, {"e", 1}}])
 
-      after_move = Game.apply_candidate_move(game, :king, {"e", 1}, {"e", 2})
+      after_move =
+        Game.apply_candidate_move(game, :king, Square.mask({"e", 1}), Square.mask({"e", 2}))
 
-      assert BitBoard.get_raw(after_move.board, {:white, :king}) == Square.bitboard({"e", 2})
+      assert BitBoard.get_raw(after_move.board, {:white, :king}) == Square.mask({"e", 2})
     end
 
     test "captures an opponent piece on the destination square" do
@@ -39,9 +40,10 @@ defmodule Chess.GameTest do
           {{:black, :pawns}, {"f", 2}}
         ])
 
-      after_move = Game.apply_candidate_move(game, :king, {"e", 1}, {"f", 2})
+      after_move =
+        Game.apply_candidate_move(game, :king, Square.mask({"e", 1}), Square.mask({"f", 2}))
 
-      assert BitBoard.get_raw(after_move.board, {:white, :king}) == Square.bitboard({"f", 2})
+      assert BitBoard.get_raw(after_move.board, {:white, :king}) == Square.mask({"f", 2})
       assert BitBoard.get_raw(after_move.board, {:black, :pawns}) == 0
     end
 
@@ -53,10 +55,11 @@ defmodule Chess.GameTest do
           {{:black, :rooks}, {"h", 8}}
         ])
 
-      after_move = Game.apply_candidate_move(game, :king, {"e", 1}, {"d", 1})
+      after_move =
+        Game.apply_candidate_move(game, :king, Square.mask({"e", 1}), Square.mask({"d", 1}))
 
-      assert BitBoard.get_raw(after_move.board, {:white, :pawns}) == Square.bitboard({"a", 2})
-      assert BitBoard.get_raw(after_move.board, {:black, :rooks}) == Square.bitboard({"h", 8})
+      assert BitBoard.get_raw(after_move.board, {:white, :pawns}) == Square.mask({"a", 2})
+      assert BitBoard.get_raw(after_move.board, {:black, :rooks}) == Square.mask({"h", 8})
     end
   end
 

--- a/test/chess/pieces_test.exs
+++ b/test/chess/pieces_test.exs
@@ -3,6 +3,7 @@ defmodule Chess.PiecesTest do
   use ExUnitProperties
 
   alias Chess.BitBoards.Pieces.{Bishop, King, Knight, Pawn, Queen, Rook}
+  alias Chess.Boards.Bitboards.Square
   alias Chess.Game
   alias Chess.Pieces
 
@@ -55,6 +56,17 @@ defmodule Chess.PiecesTest do
 
     test "returns {:error, :unoccupied} for squares occupied by the player of the other color" do
       assert {:error, :unoccupied} = Pieces.classify(Game.new(), {"a", 8})
+    end
+
+    test "classifies via a square mask without a tuple" do
+      game = Game.new()
+
+      assert {:ok, King} = Pieces.classify(game, Square.mask({"e", 1}))
+
+      assert {:ok, Pawn} =
+               Pieces.classify(game, Square.mask_from_index(Square.to_index({"a", 2})))
+
+      assert {:error, :unoccupied} = Pieces.classify(game, Square.mask({"e", 4}))
     end
 
     property "returns {:error, :unoccupied} for blank squares" do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 2** of #67: attack and simulation call sites now work with square masks instead of repeatedly converting `{file, rank}` tuples.

### Changes

- **`Attacks.square_attacked_by?/3`** — accepts a single-bit `Square.mask()`; drops the internal `Square.bitboard/1` conversion
- **`King.in_check?/1`** — passes the king bitboard mask directly to attack detection (no `from_bitboard/1` round-trip)
- **`Game.apply_candidate_move/4`** — takes from/to masks; `King` converts once at the validator safety check
- **`Pieces.classify/2`** — classifies via `BitBoard.occupied?/2` mask intersection; keeps a tuple clause for the proposal / test boundary

### Acceptance

King-safety simulation and attack checks perform no tuple→mask conversion inside loops / recursive checks.

### Verification

- `mix credo --strict` — clean
- `mix format --check-formatted` — clean
- `mix test` — 500 passed

Refs: #66, #67

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc24f-77e9-7064-9ee4-3c752165885d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc24f-77e9-7064-9ee4-3c752165885d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

