### PR TITLE
Phase 3: castling/King mask APIs + O(1) castling rights

### DIFF
--- a/lib/chess/board/bitboards/castling.ex
+++ b/lib/chess/board/bitboards/castling.ex
@@ -2,10 +2,14 @@ defmodule Chess.Bitboards.Castling do
   @moduledoc """
   Static castling geometry for bitboard move validation.
 
-  Owns king/rook home squares, king destinations, path masks (squares that
+  Owns king/rook home masks, king destination masks, path masks (squares that
   must be empty), and transit masks (squares that must be unattacked).
   Consumers compose these masks with occupancy or attack bitboards via
   bitwise AND rather than iterating coordinates.
+
+  Coordinate tuples are retained only as compile-time source data for mask
+  generation and documentation; the public API returns and accepts
+  `Square.mask()` values on the hot path.
   """
 
   import Bitwise
@@ -15,19 +19,20 @@ defmodule Chess.Bitboards.Castling do
 
   @type side() :: :kingside | :queenside
 
-  @king_homes %{
+  # Tuple constants — source data for compile-time mask generation / docs.
+  @king_home_squares %{
     white: {"e", 1},
     black: {"e", 8}
   }
 
-  @king_destinations %{
+  @king_destination_squares %{
     {:white, :kingside} => {"g", 1},
     {:white, :queenside} => {"c", 1},
     {:black, :kingside} => {"g", 8},
     {:black, :queenside} => {"c", 8}
   }
 
-  @rook_homes %{
+  @rook_home_squares %{
     {:white, :kingside} => {"h", 1},
     {:white, :queenside} => {"a", 1},
     {:black, :kingside} => {"h", 8},
@@ -50,31 +55,43 @@ defmodule Chess.Bitboards.Castling do
     {:black, :queenside} => [{"e", 8}, {"d", 8}, {"c", 8}]
   }
 
+  @king_home_masks Map.new(@king_home_squares, fn {color, square} ->
+                     {color, Square.mask(square)}
+                   end)
+
+  @king_destination_masks Map.new(@king_destination_squares, fn {key, square} ->
+                            {key, Square.mask(square)}
+                          end)
+
+  @rook_home_masks Map.new(@rook_home_squares, fn {key, square} ->
+                     {key, Square.mask(square)}
+                   end)
+
   @path_masks Map.new(@path_squares, fn {key, squares} ->
-                {key, squares |> Enum.map(&Square.bitboard/1) |> Enum.reduce(0, &bor/2)}
+                {key, squares |> Enum.map(&Square.mask/1) |> Enum.reduce(0, &bor/2)}
               end)
 
   @transit_masks Map.new(@transit_squares, fn {key, squares} ->
-                   {key, squares |> Enum.map(&Square.bitboard/1) |> Enum.reduce(0, &bor/2)}
+                   {key, squares |> Enum.map(&Square.mask/1) |> Enum.reduce(0, &bor/2)}
                  end)
 
   @doc """
-  Returns the king's starting square for `color`.
+  Returns the king's starting square mask for `color`.
   """
-  @spec king_home(Color.t()) :: Square.t()
-  def king_home(color), do: Map.fetch!(@king_homes, color)
+  @spec king_home(Color.t()) :: Square.mask()
+  def king_home(color), do: Map.fetch!(@king_home_masks, color)
 
   @doc """
-  Returns the rook's starting square for `color` and castling `side`.
+  Returns the rook's starting square mask for `color` and castling `side`.
   """
-  @spec rook_home(Color.t(), side()) :: Square.t()
-  def rook_home(color, side), do: Map.fetch!(@rook_homes, {color, side})
+  @spec rook_home(Color.t(), side()) :: Square.mask()
+  def rook_home(color, side), do: Map.fetch!(@rook_home_masks, {color, side})
 
   @doc """
-  Returns the king's destination square for `color` and castling `side`.
+  Returns the king's destination square mask for `color` and castling `side`.
   """
-  @spec king_destination(Color.t(), side()) :: Square.t()
-  def king_destination(color, side), do: Map.fetch!(@king_destinations, {color, side})
+  @spec king_destination(Color.t(), side()) :: Square.mask()
+  def king_destination(color, side), do: Map.fetch!(@king_destination_masks, {color, side})
 
   @doc """
   Bitboard mask of squares that must be empty for `color` to castle `side`.
@@ -99,16 +116,21 @@ defmodule Chess.Bitboards.Castling do
   def transit_mask(color, side), do: Map.fetch!(@transit_masks, {color, side})
 
   @doc """
-  Classifies a king move from `source` to `destination` as kingside or
-  queenside castling for `color`.
+  Classifies a king move from `source_mask` to `destination_mask` as kingside
+  or queenside castling for `color`.
+
+  Both arguments are single-bit `Square.mask()` values — convert from
+  `{file, rank}` once at the validator boundary.
   """
-  @spec side(Color.t(), Square.t(), Square.t()) :: {:ok, side()} | {:error, :cannot_castle}
-  def side(color, source, destination) do
+  @spec side(Color.t(), Square.mask(), Square.mask()) ::
+          {:ok, side()} | {:error, :cannot_castle}
+  def side(color, source_mask, destination_mask)
+      when is_integer(source_mask) and is_integer(destination_mask) do
     home = king_home(color)
     kingside = king_destination(color, :kingside)
     queenside = king_destination(color, :queenside)
 
-    case {source, destination} do
+    case {source_mask, destination_mask} do
       {^home, ^kingside} -> {:ok, :kingside}
       {^home, ^queenside} -> {:ok, :queenside}
       _ -> {:error, :cannot_castle}

--- a/lib/chess/board/bitboards/pieces/king.ex
+++ b/lib/chess/board/bitboards/pieces/king.ex
@@ -5,12 +5,10 @@ defmodule Chess.BitBoards.Pieces.King do
   Orchestrates geometry, self-capture, king-safety, and castling checks.
   Castling geometry lives in `Chess.Bitboards.Castling`; attack detection
   lives in `Chess.Bitboards.Attacks`; candidate-move simulation lives on
-  `Chess.Boards.BitBoard`.
+  `Chess.Boards.BitBoard`. Castling rights are read from `Game` in O(1).
   """
 
   @behaviour Chess.Moves.Validator
-
-  import Bitwise
 
   alias Chess.Bitboards.Attacks
   alias Chess.Bitboards.Castling
@@ -23,8 +21,11 @@ defmodule Chess.BitBoards.Pieces.King do
   @impl Chess.Moves.Validator
   @spec validate_move(Game.t(), Proposals.t()) :: {:ok, Move.t()} | {:error, atom()}
   def validate_move(game, %Proposals{source: source, destination: destination}) do
+    from_mask = Square.mask(source)
+    to_mask = Square.mask(destination)
+
     with {:ok, move_type} <- classify_geometry(source, destination) do
-      validate_typed_move(move_type, game, source, destination)
+      validate_typed_move(move_type, game, source, destination, from_mask, to_mask)
     end
   end
 
@@ -42,6 +43,8 @@ defmodule Chess.BitBoards.Pieces.King do
     end
   end
 
+  # Geometry uses integer file/rank codepoints (`?a`..`?h`) and ranks —
+  # not string file compares — then castling continues on masks.
   defp classify_geometry({<<from_file>>, from_rank}, {<<to_file>>, to_rank}) do
     file_delta = abs(to_file - from_file)
     rank_delta = abs(to_rank - from_rank)
@@ -54,15 +57,15 @@ defmodule Chess.BitBoards.Pieces.King do
     end
   end
 
-  defp validate_typed_move(:step, game, source, destination) do
-    with :ok <- validate_not_self_capture(game, destination),
-         :ok <- validate_king_safety(game, source, destination) do
+  defp validate_typed_move(:step, game, source, destination, from_mask, to_mask) do
+    with :ok <- validate_not_self_capture(game, to_mask),
+         :ok <- validate_king_safety(game, from_mask, to_mask) do
       {:ok, Move.make(game, source, destination)}
     end
   end
 
-  defp validate_typed_move(:castle, game, source, destination) do
-    with {:ok, side} <- Castling.side(game.current_player, source, destination),
+  defp validate_typed_move(:castle, game, source, destination, from_mask, to_mask) do
+    with {:ok, side} <- Castling.side(game.current_player, from_mask, to_mask),
          :ok <- validate_castling_rights(game, side),
          :ok <- validate_castling_path_clear(game, side),
          :ok <- validate_castling_safe(game, side) do
@@ -70,18 +73,17 @@ defmodule Chess.BitBoards.Pieces.King do
     end
   end
 
-  defp validate_not_self_capture(game, destination) do
-    if occupied_by?(game.board, game.current_player, destination) do
+  defp validate_not_self_capture(game, to_mask) do
+    own_pieces = BitBoard.get_raw(game.board, game.current_player)
+
+    if BitBoard.occupied?(own_pieces, to_mask) do
       {:error, :self_capture}
     else
       :ok
     end
   end
 
-  defp validate_king_safety(game, source, destination) do
-    from_mask = Square.mask(source)
-    to_mask = Square.mask(destination)
-
+  defp validate_king_safety(game, from_mask, to_mask) do
     if game |> Game.apply_candidate_move(:king, from_mask, to_mask) |> in_check?() do
       {:error, :king_in_check}
     else
@@ -91,26 +93,19 @@ defmodule Chess.BitBoards.Pieces.King do
 
   defp validate_castling_rights(game, side) do
     color = game.current_player
-    rook_square = Castling.rook_home(color, side)
+    rook_mask = Castling.rook_home(color, side)
 
-    with :ok <- require_unmoved(game.move_list, Castling.king_home(color)),
-         :ok <- require_unmoved(game.move_list, rook_square) do
-      require_rook_present(game.board, color, rook_square)
-    end
-  end
-
-  defp require_unmoved(move_list, square) do
-    if piece_has_moved?(move_list, square) do
-      {:error, :cannot_castle}
+    if Game.can_castle?(game, color, side) do
+      require_rook_present(game.board, color, rook_mask)
     else
-      :ok
+      {:error, :cannot_castle}
     end
   end
 
-  defp require_rook_present(board, color, square) do
+  defp require_rook_present(board, color, rook_mask) do
     rooks = BitBoard.get_raw(board, {color, :rooks})
 
-    if (rooks &&& Square.bitboard(square)) != 0 do
+    if BitBoard.occupied?(rooks, rook_mask) do
       :ok
     else
       {:error, :cannot_castle}
@@ -135,15 +130,5 @@ defmodule Chess.BitBoards.Pieces.King do
     else
       :ok
     end
-  end
-
-  defp piece_has_moved?(move_list, square) do
-    Enum.any?(move_list, fn %Move{from: from} -> from == square end)
-  end
-
-  defp occupied_by?(board, color, square) do
-    board
-    |> BitBoard.get(color)
-    |> BitBoard.square_occupied?(square)
   end
 end

--- a/lib/chess/game.ex
+++ b/lib/chess/game.ex
@@ -7,15 +7,20 @@ defmodule Chess.Game do
   alias Chess.Boards.BitBoard
   alias Chess.Boards.Bitboards.Square
   alias Chess.Color
+  alias Chess.Game.CastlingRights
 
   defstruct board: BitBoard.new(),
             move_list: [],
-            current_player: Color.white()
+            current_player: Color.white(),
+            white_castling: %CastlingRights{},
+            black_castling: %CastlingRights{}
 
   @type t() :: %__MODULE__{
           board: BitBoard.t(),
           move_list: list(Move.t()),
-          current_player: Chess.player()
+          current_player: Chess.player(),
+          white_castling: CastlingRights.t(),
+          black_castling: CastlingRights.t()
         }
 
   @doc """
@@ -29,6 +34,41 @@ defmodule Chess.Game do
   @spec opponent(t()) :: Chess.player()
   def opponent(%__MODULE__{current_player: :white}), do: :black
   def opponent(%__MODULE__{current_player: :black}), do: :white
+
+  @doc """
+  Returns the castling rights for `color`.
+  """
+  @spec castling_rights(t(), Color.t()) :: CastlingRights.t()
+  def castling_rights(%__MODULE__{white_castling: rights}, :white), do: rights
+  def castling_rights(%__MODULE__{black_castling: rights}, :black), do: rights
+
+  @doc """
+  Returns true when `color` may still castle on `side` according to stored
+  rights (independent of path clearance and check).
+  """
+  @spec can_castle?(t(), Color.t(), CastlingRights.side()) :: boolean()
+  def can_castle?(%__MODULE__{} = game, color, side) do
+    game
+    |> castling_rights(color)
+    |> CastlingRights.available?(side)
+  end
+
+  @doc """
+  Clears castling rights for `color`.
+
+  Pass `:king` to revoke both sides, or `:kingside` / `:queenside` for one side.
+  Intended for move application when the king or a rook moves (or a rook is
+  captured); validation reads rights via `can_castle?/3` in O(1).
+  """
+  @spec revoke_castling(t(), Color.t(), CastlingRights.revoke_target()) :: t()
+  def revoke_castling(%__MODULE__{} = game, color, target) do
+    rights =
+      game
+      |> castling_rights(color)
+      |> CastlingRights.revoke(target)
+
+    put_castling_rights(game, color, rights)
+  end
 
   @doc """
   Applies a candidate move for validation / king-safety simulation.
@@ -57,6 +97,9 @@ defmodule Chess.Game do
 
     %{game | board: updated_board}
   end
+
+  defp put_castling_rights(game, :white, rights), do: %{game | white_castling: rights}
+  defp put_castling_rights(game, :black, rights), do: %{game | black_castling: rights}
 
   ##########################################
   # Tentative interface for game play here #

--- a/lib/chess/game/castling_rights.ex
+++ b/lib/chess/game/castling_rights.ex
@@ -1,0 +1,50 @@
+defmodule Chess.Game.CastlingRights do
+  @moduledoc """
+  Per-color castling availability for a side.
+
+  Both kingside and queenside start available. Rights are cleared when the
+  king moves (both sides), when the corresponding rook moves, or when that
+  rook is captured — callers update via `revoke/2`. Validators read these
+  flags in constant time instead of scanning `Game.move_list`.
+  """
+
+  @type side() :: :kingside | :queenside
+  @type revoke_target() :: :king | side()
+
+  @type t() :: %__MODULE__{
+          kingside: boolean(),
+          queenside: boolean()
+        }
+
+  defstruct kingside: true, queenside: true
+
+  @doc """
+  Returns full castling rights (both sides available).
+  """
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Returns rights with neither side available.
+  """
+  @spec none() :: t()
+  def none, do: %__MODULE__{kingside: false, queenside: false}
+
+  @doc """
+  Returns true when castling on `side` is still allowed.
+  """
+  @spec available?(t(), side()) :: boolean()
+  def available?(%__MODULE__{kingside: kingside}, :kingside), do: kingside
+  def available?(%__MODULE__{queenside: queenside}, :queenside), do: queenside
+
+  @doc """
+  Clears castling rights for a revoke target.
+
+  Revoking `:king` clears both sides; revoking `:kingside` or `:queenside`
+  clears only that side.
+  """
+  @spec revoke(t(), revoke_target()) :: t()
+  def revoke(%__MODULE__{}, :king), do: none()
+  def revoke(%__MODULE__{} = rights, :kingside), do: %{rights | kingside: false}
+  def revoke(%__MODULE__{} = rights, :queenside), do: %{rights | queenside: false}
+end

--- a/test/chess/board/bitboards/castling_test.exs
+++ b/test/chess/board/bitboards/castling_test.exs
@@ -12,19 +12,19 @@ defmodule Chess.Bitboards.CastlingTest do
     end
 
     test "returns false when any kingside path square is occupied" do
-      occupied = Square.bitboard({"f", 1})
+      occupied = Square.mask({"f", 1})
 
       refute Castling.path_clear?(occupied, :white, :kingside)
     end
 
     test "returns false when any queenside path square is occupied" do
-      occupied = Square.bitboard({"b", 1})
+      occupied = Square.mask({"b", 1})
 
       refute Castling.path_clear?(occupied, :white, :queenside)
     end
 
     test "ignores occupancy outside the castling path" do
-      occupied = Square.bitboard({"a", 2}) ||| Square.bitboard({"h", 8})
+      occupied = Square.mask({"a", 2}) ||| Square.mask({"h", 8})
 
       assert Castling.path_clear?(occupied, :white, :kingside)
       assert Castling.path_clear?(occupied, :white, :queenside)
@@ -33,7 +33,7 @@ defmodule Chess.Bitboards.CastlingTest do
 
   describe "path_mask/2" do
     test "is the bitwise OR of each path square" do
-      expected = Square.bitboard({"f", 1}) ||| Square.bitboard({"g", 1})
+      expected = Square.mask({"f", 1}) ||| Square.mask({"g", 1})
 
       assert Castling.path_mask(:white, :kingside) == expected
     end
@@ -42,20 +42,38 @@ defmodule Chess.Bitboards.CastlingTest do
   describe "transit_mask/2" do
     test "is the bitwise OR of king start, pass-through, and landing squares" do
       expected =
-        Square.bitboard({"e", 1}) ||| Square.bitboard({"f", 1}) ||| Square.bitboard({"g", 1})
+        Square.mask({"e", 1}) ||| Square.mask({"f", 1}) ||| Square.mask({"g", 1})
 
       assert Castling.transit_mask(:white, :kingside) == expected
     end
   end
 
+  describe "home and destination masks" do
+    test "king_home/1 returns the starting square mask" do
+      assert Castling.king_home(:white) == Square.mask({"e", 1})
+      assert Castling.king_home(:black) == Square.mask({"e", 8})
+    end
+
+    test "rook_home/2 and king_destination/2 return masks" do
+      assert Castling.rook_home(:white, :kingside) == Square.mask({"h", 1})
+      assert Castling.rook_home(:white, :queenside) == Square.mask({"a", 1})
+      assert Castling.king_destination(:white, :kingside) == Square.mask({"g", 1})
+      assert Castling.king_destination(:white, :queenside) == Square.mask({"c", 1})
+    end
+  end
+
   describe "side/3" do
-    test "classifies white kingside and queenside castling" do
-      assert {:ok, :kingside} = Castling.side(:white, {"e", 1}, {"g", 1})
-      assert {:ok, :queenside} = Castling.side(:white, {"e", 1}, {"c", 1})
+    test "classifies white kingside and queenside castling by mask" do
+      assert {:ok, :kingside} =
+               Castling.side(:white, Square.mask({"e", 1}), Square.mask({"g", 1}))
+
+      assert {:ok, :queenside} =
+               Castling.side(:white, Square.mask({"e", 1}), Square.mask({"c", 1}))
     end
 
     test "rejects non-castling destinations from the king home square" do
-      assert {:error, :cannot_castle} = Castling.side(:white, {"e", 1}, {"e", 2})
+      assert {:error, :cannot_castle} =
+               Castling.side(:white, Square.mask({"e", 1}), Square.mask({"e", 2}))
     end
   end
 end

--- a/test/chess/board/bitboards/pieces/king_test.exs
+++ b/test/chess/board/bitboards/pieces/king_test.exs
@@ -276,8 +276,8 @@ defmodule Chess.BitBoards.Pieces.KingTest do
     end
 
     test "rejects castling when the king has previously moved" do
-      # Board state: Same as kingside castling success, but move_list contains
-      #              a prior king move (king moved away and back to e1).
+      # Board state: Same as kingside castling success, but white castling
+      #              rights were revoked when the king moved earlier.
       # Move: e1 -> g1
       # Expected: {:error, :cannot_castle}
       game =
@@ -285,10 +285,20 @@ defmodule Chess.BitBoards.Pieces.KingTest do
           {{:white, :king}, {"e", 1}},
           {{:white, :rooks}, {"h", 1}}
         ])
-        |> Map.put(:move_list, [
-          %Move{from: {"e", 1}, to: {"e", 2}, flag: :quiet},
-          %Move{from: {"e", 2}, to: {"e", 1}, flag: :quiet}
+        |> Game.revoke_castling(:white, :king)
+
+      proposal = %Proposals{source: {"e", 1}, destination: {"g", 1}}
+
+      assert {:error, :cannot_castle} = King.validate_move(game, proposal)
+    end
+
+    test "rejects castling when only the castling-side rook rights were revoked" do
+      game =
+        game_with([
+          {{:white, :king}, {"e", 1}},
+          {{:white, :rooks}, {"h", 1}}
         ])
+        |> Game.revoke_castling(:white, :kingside)
 
       proposal = %Proposals{source: {"e", 1}, destination: {"g", 1}}
 

--- a/test/chess/game/castling_rights_test.exs
+++ b/test/chess/game/castling_rights_test.exs
@@ -1,0 +1,37 @@
+defmodule Chess.Game.CastlingRightsTest do
+  use ExUnit.Case, async: true
+
+  alias Chess.Game.CastlingRights
+
+  describe "new/0" do
+    test "both sides are available" do
+      rights = CastlingRights.new()
+
+      assert CastlingRights.available?(rights, :kingside)
+      assert CastlingRights.available?(rights, :queenside)
+    end
+  end
+
+  describe "revoke/2" do
+    test "revoking the king clears both sides" do
+      rights = CastlingRights.new() |> CastlingRights.revoke(:king)
+
+      refute CastlingRights.available?(rights, :kingside)
+      refute CastlingRights.available?(rights, :queenside)
+    end
+
+    test "revoking kingside leaves queenside" do
+      rights = CastlingRights.new() |> CastlingRights.revoke(:kingside)
+
+      refute CastlingRights.available?(rights, :kingside)
+      assert CastlingRights.available?(rights, :queenside)
+    end
+
+    test "revoking queenside leaves kingside" do
+      rights = CastlingRights.new() |> CastlingRights.revoke(:queenside)
+
+      assert CastlingRights.available?(rights, :kingside)
+      refute CastlingRights.available?(rights, :queenside)
+    end
+  end
+end

--- a/test/chess/game_test.exs
+++ b/test/chess/game_test.exs
@@ -5,11 +5,17 @@ defmodule Chess.GameTest do
   alias Chess.Boards.Bitboards.Square
   alias Chess.Color
   alias Chess.Game
+  alias Chess.Game.CastlingRights
 
   describe "new/0" do
     test "creates a new chess game instance" do
-      assert %Game{board: BitBoard.new(), move_list: [], current_player: Color.white()} ==
-               Game.new()
+      assert %Game{
+               board: BitBoard.new(),
+               move_list: [],
+               current_player: Color.white(),
+               white_castling: %CastlingRights{kingside: true, queenside: true},
+               black_castling: %CastlingRights{kingside: true, queenside: true}
+             } == Game.new()
     end
   end
 
@@ -20,6 +26,33 @@ defmodule Chess.GameTest do
 
     test "returns white when black is to move" do
       assert Game.opponent(%Game{current_player: :black}) == :white
+    end
+  end
+
+  describe "castling rights" do
+    test "both sides start with kingside and queenside available" do
+      game = Game.new()
+
+      assert Game.can_castle?(game, :white, :kingside)
+      assert Game.can_castle?(game, :white, :queenside)
+      assert Game.can_castle?(game, :black, :kingside)
+      assert Game.can_castle?(game, :black, :queenside)
+    end
+
+    test "revoking the king clears both sides for that color only" do
+      game = Game.new() |> Game.revoke_castling(:white, :king)
+
+      refute Game.can_castle?(game, :white, :kingside)
+      refute Game.can_castle?(game, :white, :queenside)
+      assert Game.can_castle?(game, :black, :kingside)
+      assert Game.can_castle?(game, :black, :queenside)
+    end
+
+    test "revoking one side leaves the other intact" do
+      game = Game.new() |> Game.revoke_castling(:black, :queenside)
+
+      assert Game.can_castle?(game, :black, :kingside)
+      refute Game.can_castle?(game, :black, :queenside)
     end
   end
 
@@ -60,6 +93,16 @@ defmodule Chess.GameTest do
 
       assert BitBoard.get_raw(after_move.board, {:white, :pawns}) == Square.mask({"a", 2})
       assert BitBoard.get_raw(after_move.board, {:black, :rooks}) == Square.mask({"h", 8})
+    end
+
+    test "does not mutate castling rights during simulation" do
+      game = Game.new()
+
+      after_move =
+        Game.apply_candidate_move(game, :king, Square.mask({"e", 1}), Square.mask({"e", 2}))
+
+      assert after_move.white_castling == game.white_castling
+      assert after_move.black_castling == game.black_castling
     end
   end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 3** of #67: castling and King validator internals now work with precomputed square masks instead of `{file, rank}` tuples on the hot path.

Also adds the castling-rights optimization discussed for this work: `Game` stores per-color rights so validators answer “can this side castle?” in constant time instead of scanning `move_list`.

### Changes

- **`Chess.Game.CastlingRights`** — `kingside` / `queenside` flags with `available?/2` and `revoke/2` (`:king` clears both)
- **`Chess.Game`** — `white_castling` / `black_castling` fields plus `can_castle?/3` and `revoke_castling/3`
- **`Chess.Bitboards.Castling`** — `king_home/1`, `rook_home/2`, `king_destination/2`, and `side/3` are mask-primary; tuple constants remain compile-time source data only
- **`Chess.BitBoards.Pieces.King`** — converts proposal squares to masks once; geometry uses file/rank integers; self-capture and rook presence use `BitBoard.occupied?/2`; castling rights via `Game.can_castle?/3` (no `move_list` scan)

### Acceptance

Castling validation uses precomputed masks + integer compares on the hot path, with O(1) rights lookup.

### Verification

- `mix credo --strict` — clean
- `mix format --check-formatted` — clean
- `mix test` — 511 passed

Refs: #66, #67

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd081-5ae5-71f5-b58a-5609801298fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd081-5ae5-71f5-b58a-5609801298fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

